### PR TITLE
Support missing dbname in mongo URI.

### DIFF
--- a/src/eduid_userdb/db.py
+++ b/src/eduid_userdb/db.py
@@ -1,3 +1,5 @@
+import copy
+
 import pymongo
 
 
@@ -16,14 +18,19 @@ class MongoDB(object):
 
         self._parsed_uri = pymongo.uri_parser.parse_uri(db_uri)
 
+        if self._parsed_uri.get('database') is None:
+            self._parsed_uri['database'] = db_name
+
         _options = self._parsed_uri.get('options')
-        if 'replicaSet' in kwargs or 'replicaSet' in _options:
+        if connection_factory is None:
+            connection_factory = pymongo.MongoClient
+        if 'replicaSet' in kwargs:
             connection_factory = pymongo.MongoReplicaSetClient
         if 'replicaSet' in _options:
             connection_factory = pymongo.MongoReplicaSetClient
             kwargs['replicaSet'] = _options['replicaSet']
-        elif connection_factory is None:
-            connection_factory = pymongo.MongoClient
+
+        self._db_uri = _format_mongodb_uri(self._parsed_uri)
 
         self._connection = connection_factory(
             host=self._db_uri,
@@ -38,23 +45,11 @@ class MongoDB(object):
         :return: db_uri
         """
         if self._sanitized_uri is None:
-            userpass = ''
-            if self._parsed_uri.get('username') is not None:
-                userpass = '{!s}:secret@'.format(self._parsed_uri.get('username'))
-            host, port = self._parsed_uri.get('nodelist')[0]
-            if port == '27017':
-                hostport = host
-            else:
-                if ':' in host and not host.endswith(']'):
-                    # IPv6 address without brackets
-                    host = '[{!s}]'.format(host)
-                hostport = '{!s}:{!s}'.format(host, port)
-
-            self._sanitized_uri = 'mongodb://{userpass!s}{hostport!s}/{dbname!s}'.format(
-                userpass = userpass,
-                hostport = hostport,
-                dbname = self._database_name,
-                )
+            _parsed = copy.copy(self._parsed_uri)
+            if 'username' in _parsed:
+                _parsed['password'] = 'secret'
+            _parsed['nodelist'] = [_parsed['nodelist'][0]]
+            self._sanitized_uri = _format_mongodb_uri(_parsed)
         return self._sanitized_uri
 
     def get_connection(self):
@@ -102,3 +97,48 @@ class MongoDB(object):
         """
         _db = self.get_database(database_name, username, password)
         return _db[collection]
+
+
+def _format_mongodb_uri(parsed_uri):
+    """
+    Painstakenly reconsttruct a MongoDB URI parsed using pymongo.uri_parser.parse_uri.
+
+    :param parsed_uri: Result of pymongo.uri_parser.parse_uri
+    :type parsed_uri: dict
+
+    :return: New URI
+    :rtype: str | unicode
+    """
+    user_pass = ''
+    if parsed_uri.get('username') and parsed_uri.get('password'):
+        user_pass = '{username!s}:{password!s}@'.format(**parsed_uri)
+
+    _nodes = []
+    for host, port in parsed_uri.get('nodelist'):
+        if ':' in host and not host.endswith(']'):
+            # IPv6 address without brackets
+            host = '[{!s}]'.format(host)
+        if port == 27017:
+            _nodes.append(host)
+        else:
+            _nodes.append('{!s}:{!s}'.format(host, port))
+    nodelist = ','.join(_nodes)
+
+    options = ''
+    if parsed_uri.get('options'):
+        _opt_list = []
+        for key, value in parsed_uri.get('options').items():
+            if isinstance(value, bool):
+                value = str(value).lower()
+            _opt_list.append('{!s}={!s}'.format(key, value))
+        options = '?' + '&'.join(_opt_list)
+
+    db_name = parsed_uri.get('database') or ''
+
+    res = "mongodb://{user_pass!s}{nodelist!s}/{db_name!s}{options!s}".format(
+        user_pass = user_pass,
+        nodelist = nodelist,
+        db_name = db_name,
+        # collection is ignored
+        options = options)
+    return res


### PR DESCRIPTION
If the dbname in the URI is empty, the user has to have access
to the 'admin' database on the mongodb server, or the connection
will fail.