### PR TITLE
The old document is removed when converting so no sync check is needed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ README = 'eduID User Database interface module'
 if os.path.exists(README_fn):
     README = open(README_fn).read()
 
-version = '0.2.1b0'
+version = '0.2.1b1'
 
 install_requires = [
     'pymongo >= 2.8.0, < 3.0',

--- a/src/eduid_userdb/proofing/proofingdb.py
+++ b/src/eduid_userdb/proofing/proofingdb.py
@@ -86,7 +86,9 @@ class ProofingStateDB(BaseDB):
             logger.debug('Proofing state eppn: {!s}'.format(eppn))
             self.remove_document({'user_id': user_id})
             logger.info('Removed user_id proofing state')
-            self.save(proofing_state)
+
+            # The old document is removed and therefore no sync check is needed
+            self.save(proofing_state, check_sync=False)
             logger.info('Saved eppn proofing state')
             return self.get_state_by_eppn(eppn, raise_on_missing)
 
@@ -143,6 +145,7 @@ class ProofingStateDB(BaseDB):
                 logging.debug("{!s} FAILED Updating state {!r} (ts {!s}) in {!r}). "
                               "ts in db = {!s}".format(self, state, modified, self._coll_name, db_ts))
                 raise DocumentOutOfSync('Stale state object can\'t be saved')
+
             logging.debug("{!s} Updated state {!r} (ts {!s}) in {!r}): {!r}".format(
                 self, state, modified, self._coll_name, result))
 


### PR DESCRIPTION
When converting a document to the new format expected by eduid-idproofing-letter, it is first removed and then saved. Therefore an exception such as the following will be thrown: "DocumentOutOfSync: <DocumentOutOfSync instance at 0x7feb4fbc10a0: "Stale state object can't be saved">" if sync checking is enabled when saving.