### PR TITLE
Remove U2F.id - use keyhandle as .key instead

### DIFF
--- a/src/eduid_userdb/authninfo.py
+++ b/src/eduid_userdb/authninfo.py
@@ -28,9 +28,9 @@ class AuthnInfoDB(BaseDB):
         """
         authninfo = []
         for credential in user.credentials.to_list():
-            auth_entry = self._coll.find_one(credential.object_id)
+            auth_entry = self._coll.find_one(credential.key)
             logger.debug("get_authn_info {!s}: cred id: {!r} auth entry: {!r}".format(
-                user, credential.object_id, auth_entry))
+                user, credential.key, auth_entry))
             if auth_entry:
                 created_dt = credential['created_ts']
                 success_dt = auth_entry['success_ts']

--- a/src/eduid_userdb/tests/test_credentials.py
+++ b/src/eduid_userdb/tests/test_credentials.py
@@ -30,7 +30,6 @@ _three_dict = {
     'source': 'test'
 }
 _four_dict = {
-    'id': ObjectId('444444444444444444444444'),
     'version': 'U2F_V2',
     'app_id': 'unit test',
     'keyhandle': 'firstU2FElement',
@@ -70,7 +69,7 @@ class TestCredentialList(TestCase):
         match = self.four.filter(U2F)
         self.assertEqual(match.count, 1)
         token = match.to_list()[0]
-        self.assertEqual(token.id, ObjectId('444444444444444444444444'))
+        self.assertEqual(token.key, 'firstU2FElement')
         self.assertEqual(token.public_key, 'foo')
 
     def test_add(self):

--- a/src/eduid_userdb/tests/test_u2f.py
+++ b/src/eduid_userdb/tests/test_u2f.py
@@ -18,21 +18,18 @@ __author__ = 'lundberg'
 #}}
 
 _one_dict = {
-    'id': ObjectId('111111111111111111111111'),
     'version': 'U2F_V2',
     'app_id': 'unit test',
     'keyhandle': 'firstU2FElement',
     'public_key': 'foo',
 }
 _two_dict = {
-    'id': ObjectId('222222222222222222222222'),
     'version': 'U2F_V2',
     'app_id': 'unit test',
     'keyhandle': 'secondU2FElement',
     'public_key': 'foo',
 }
 _three_dict = {
-    'id': ObjectId('333333333333333333333333'),
     'version': 'U2F_V2',
     'app_id': 'unit test',
     'keyhandle': 'thirdU2FElement',
@@ -50,18 +47,13 @@ class TestU2F(TestCase):
 
     def test_key(self):
         """
-        Test that the 'key' property (used by CredentialList) works for the Password.
+        Test that the 'key' property (used by CredentialList) works for the credential.
         """
-        this = self.one.find(ObjectId('111111111111111111111111'))
-        self.assertEqual(this.key, this.id)
-
-    def test_setting_invalid_id(self):
-        this = self.one.find(ObjectId('111111111111111111111111'))
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.id = None
+        this = self.one.find('firstU2FElement')
+        self.assertEqual(this.key, this.keyhandle)
 
     def test_setting_invalid_keyhandle(self):
-        this = self.one.find(ObjectId('111111111111111111111111'))
+        this = self.one.find('firstU2FElement')
         with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
             this.keyhandle = None
 
@@ -88,14 +80,14 @@ class TestU2F(TestCase):
         self.assertEqual(out['foo'], one['foo'])
 
     def test_created_by(self):
-        this = self.three.find(ObjectId('333333333333333333333333'))
+        this = self.three.find('thirdU2FElement')
         this.created_by = 'unit test'
         self.assertEqual(this.created_by, 'unit test')
         with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
             this.created_by = False
 
     def test_modify_created_by(self):
-        this = self.three.find(ObjectId('333333333333333333333333'))
+        this = self.three.find('thirdU2FElement')
         with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
             this.created_by = 1
         this.created_by = 'unit test'
@@ -105,14 +97,14 @@ class TestU2F(TestCase):
             this.created_by = 'test unit'
 
     def test_created_ts(self):
-        this = self.three.find(ObjectId('333333333333333333333333'))
+        this = self.three.find('thirdU2FElement')
         this.created_ts = True
         self.assertIsInstance(this.created_ts, datetime.datetime)
         with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
             this.created_ts = False
 
     def test_modify_created_ts(self):
-        this = self.three.find(ObjectId('333333333333333333333333'))
+        this = self.three.find('thirdU2FElement')
         this.created_ts = datetime.datetime.utcnow()
         with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
             this.created_ts = None

--- a/src/eduid_userdb/u2f.py
+++ b/src/eduid_userdb/u2f.py
@@ -33,7 +33,6 @@
 # Author : Fredrik Thulin <fredrik@thulin.net>
 #
 import copy
-from bson.objectid import ObjectId
 from six import string_types
 from eduid_userdb.element import Element
 from eduid_userdb.exceptions import UserHasUnknownData, UserDBValueError
@@ -46,7 +45,7 @@ class U2F(Element):
     U2F token authentication credential
     """
 
-    def __init__(self, credential_id=None,
+    def __init__(self,
                  version=None, keyhandle=None, public_key=None, app_id=None, attest_cert=None,
                  description=None,
                  application=None, created_ts=None, data=None,
@@ -57,8 +56,7 @@ class U2F(Element):
         if data is None:
             if created_ts is None:
                 created_ts = True
-            data = dict(id = credential_id,
-                        version = version,
+            data = dict(version = version,
                         keyhandle = keyhandle,
                         public_key = public_key,
                         app_id = app_id,
@@ -69,7 +67,6 @@ class U2F(Element):
                         )
 
         Element.__init__(self, data)
-        self.id = data.pop('id')
         self.version = data.pop('version')
         self.keyhandle = data.pop('keyhandle')
         self.public_key = data.pop('public_key')
@@ -81,7 +78,7 @@ class U2F(Element):
         if leftovers:
             if raise_on_unknown:
                 raise UserHasUnknownData('U2F {!r} unknown data: {!r}'.format(
-                    self.id, leftovers,
+                    self.key, leftovers,
                 ))
             # Just keep everything that is left as-is
             self._data.update(data)
@@ -91,27 +88,7 @@ class U2F(Element):
         """
         Return the element that is used as key.
         """
-        return self.id
-
-    @property
-    def id(self):
-        """
-        This is a reference to the ObjectId in the authentication private database.
-
-        :return: Unique ID of password.
-        :rtype: bson.ObjectId
-        """
-        return self._data['id']
-
-    @id.setter
-    def id(self, value):
-        """
-        :param value: Unique ID of password.
-        :type value: bson.ObjectId
-        """
-        if not isinstance(value, ObjectId):
-            raise UserDBValueError("Invalid 'id': {!r}".format(value))
-        self._data['id'] = value
+        return self.keyhandle
 
     @property
     def version(self):


### PR DESCRIPTION
'id' was a leftover from passwords, where it was a reference to the
credential in the authentication backend database.