### PR TITLE
Eperez refactor testing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ README = 'eduID User Database interface module'
 if os.path.exists(README_fn):
     README = open(README_fn).read()
 
-version = '0.4.6b15'
+version = '0.4.6b16'
 
 install_requires = [
     'pymongo >= 3.6',

--- a/src/eduid_userdb/testing.py
+++ b/src/eduid_userdb/testing.py
@@ -253,7 +253,7 @@ class MongoTestCase(unittest.TestCase):
     user = User(data=MOCKED_USER_STANDARD)
     mock_users_patches = []
 
-    def setUp(self, init_am=False, userdb_use_old_format=False, am_settings=None):
+    def setUp(self):
         """
         Test case initialization.
 
@@ -270,53 +270,11 @@ class MongoTestCase(unittest.TestCase):
                 def setUp(self):
                     super(MyTest, self).setUp(celery, get_attribute_manager)
                     ...
-
-        :param init_am: True if the test needs am
-        :param userdb_use_old_format: True if old userdb format should be used
-        :param am_settings: Test specific am settings
-        :return:
         """
         super(MongoTestCase, self).setUp()
         self.tmp_db = MongoTemporaryInstance.get_instance()
 
-        if init_am:
-            self.am_settings = {
-                'CELERY': {'broker_transport': 'memory',
-                           'broker_url': 'memory://',
-                           'task_eager_propagates': True,
-                           'task_always_eager': True,
-                           'result_backend': 'cache',
-                           'cache_backend': 'memory',
-                           },
-                # Be sure to NOT tell AttributeManager about the temporary mongodb instance.
-                # If we do, one or more plugins may open DB connections that never gets closed.
-                'MONGO_URI': None,
-            }
-
-            if am_settings:
-                want_mongo_uri = am_settings.pop('WANT_MONGO_URI', False)
-                self.am_settings.update(am_settings)
-                if want_mongo_uri:
-                    self.am_settings['MONGO_URI'] = self.tmp_db.uri
-            # initialize eduid_am without requiring config in etcd
-            import eduid_am
-            celery = eduid_am.init_app(self.am_settings['CELERY'])
-            import eduid_am.worker
-            eduid_am.worker.worker_config = self.am_settings
-            logger.debug('Initialized AM with config:\n{!r}'.format(self.am_settings))
-
-            self.am = eduid_am.get_attribute_manager(celery)
         self.amdb = UserDB(self.tmp_db.uri, 'eduid_am')
-
-        mongo_settings = {
-            'mongo_replicaset': None,
-            'mongo_uri': self.tmp_db.uri,
-        }
-
-        if getattr(self, 'settings', None) is None:
-            self.settings = mongo_settings
-        else:
-            self.settings.update(mongo_settings)
 
         # Set up test users in the MongoDB. Read the users from MockedUserDB, which might
         # be overridden by subclasses.
@@ -324,7 +282,7 @@ class MongoTestCase(unittest.TestCase):
         for userdoc in _foo_userdb.all_userdocs():
             this = deepcopy(userdoc)  # deep-copy to not have side effects between tests
             user = User(data=this)
-            self.amdb.save(user, check_sync=False, old_format=userdb_use_old_format)
+            self.amdb.save(user, check_sync=False)
 
     def tearDown(self):
         for userdoc in self.amdb._get_all_docs():
@@ -337,7 +295,3 @@ class MongoTestCase(unittest.TestCase):
         self.amdb._drop_whole_collection()
         self.amdb.close()
         super(MongoTestCase, self).tearDown()
-
-    #def mongodb_uri(self, dbname):
-    #    self.assertIsNotNone(dbname)
-    #    return self.tmp_db.uri + '/' + dbname

--- a/src/eduid_userdb/testing.py
+++ b/src/eduid_userdb/testing.py
@@ -44,7 +44,6 @@ import subprocess
 import time
 import unittest
 from copy import deepcopy
-from datetime import date, timedelta
 
 import pymongo
 from bson import ObjectId

--- a/src/eduid_userdb/tests/test_actions_db.py
+++ b/src/eduid_userdb/tests/test_actions_db.py
@@ -87,7 +87,7 @@ TOU_ACTION_USERID = {
 class TestActionsDB(MongoTestCase):
 
     def setUp(self):
-        super(TestActionsDB, self).setUp(None, None)
+        super(TestActionsDB, self).setUp()
         self.actionsdb = ActionDB(self.tmp_db.uri)
         self.actionsdb.add_action(data=TOU_ACTION)
         self.actionsdb.add_action(data=DUMMY_ACTION)
@@ -124,7 +124,7 @@ class TestActionsDB(MongoTestCase):
 class TestActionsDBUserid(MongoTestCase):
 
     def setUp(self):
-        super(TestActionsDBUserid, self).setUp(None, None)
+        super(TestActionsDBUserid, self).setUp()
         self.actionsdb = ActionDB(self.tmp_db.uri)
         self.actionsdb.add_action(data=TOU_ACTION_USERID)
         self.actionsdb.add_action(data=DUMMY_ACTION_USERID)

--- a/src/eduid_userdb/tests/test_userdb.py
+++ b/src/eduid_userdb/tests/test_userdb.py
@@ -40,7 +40,7 @@ from datetime import datetime
 class TestUserDB(MongoTestCase):
 
     def setUp(self):
-        super(TestUserDB, self).setUp(None, None)
+        super(TestUserDB, self).setUp()
 
     def test_get_user_by_id(self):
         """ Test get_user_by_id """
@@ -99,7 +99,7 @@ class TestUserDB(MongoTestCase):
 class TestUserDB_mail(MongoTestCase):
 
     def setUp(self):
-        super(TestUserDB_mail, self).setUp(None, None)
+        super(TestUserDB_mail, self).setUp()
         data1 = {u'_id': bson.ObjectId(),
                  u'eduPersonPrincipalName': u'mail-test1',
                  u'mail': u'test@gmail.com',
@@ -150,7 +150,7 @@ class TestUserDB_mail(MongoTestCase):
 class TestUserDB_phone(MongoTestCase):
 
     def setUp(self):
-        super(TestUserDB_phone, self).setUp(None, None)
+        super(TestUserDB_phone, self).setUp()
         data1 = {u'_id': bson.ObjectId(),
                  u'eduPersonPrincipalName': u'phone-test1',
                  u'mail': u'kalle@example.com',
@@ -231,7 +231,7 @@ class TestUserDB_phone(MongoTestCase):
 class TestUserDB_nin(MongoTestCase):
 
     def setUp(self):
-        super(TestUserDB_nin, self).setUp(None, None)
+        super(TestUserDB_nin, self).setUp()
         data1 = {u'_id': bson.ObjectId(),
                  u'eduPersonPrincipalName': u'nin-test1',
                  u'mail': u'kalle@example.com',


### PR DESCRIPTION
A PR for eduid-userdb, refactoring the MongoTestCase. The rationale is that MongoTestCase is setting up AM stuff, but from now on, to do so, we need the new config dataclasses, that reside in eduid-common. The tests in euid-userdb do not need AM stuff, so I am moving the AM setup to the test cases in eduid-common. This will obviously not work with the current master of eduid-common and dependants, so I'm bumping the version.