### PR TITLE
linting

### DIFF
--- a/src/eduid_userdb/actions/chpass/user.py
+++ b/src/eduid_userdb/actions/chpass/user.py
@@ -57,7 +57,7 @@ class ChpassUser(User):
     """
 
     def __init__(self, userid = None, passwords = None, data = None,
-                                         raise_on_unknown = True):
+                 raise_on_unknown = True):
         """
         """
         if data is None:
@@ -91,7 +91,7 @@ class ChpassUser(User):
                 ))
             # Just keep everything that is left as-is
             self._data.update(self._data_in)
-    
+
     @classmethod
     def from_central_user(cls, user):
         '''
@@ -101,10 +101,10 @@ class ChpassUser(User):
         :type user: eduid_userdb.user.User
         '''
         data = {
-                '_id': user.user_id,
-                'passwords': user.credentials.to_list_of_dicts(),
-                'modified_ts': user.modified_ts
-            }
+            '_id': user.user_id,
+            'passwords': user.credentials.to_list_of_dicts(),
+            'modified_ts': user.modified_ts
+        }
         return cls(data=data)
 
     # -----------------------------------------------------------------
@@ -119,7 +119,5 @@ class ChpassUser(User):
         :rtype: dict
         """
         res = deepcopy(self._data)  # avoid caller messing up our private _data
-        res['passwords'] = self.credentials.to_list_of_dicts(
-                old_userdb_format=old_userdb_format)
+        res['passwords'] = self.credentials.to_list_of_dicts(old_userdb_format=old_userdb_format)
         return res
-

--- a/src/eduid_userdb/actions/chpass/userdb.py
+++ b/src/eduid_userdb/actions/chpass/userdb.py
@@ -42,4 +42,3 @@ class ChpassUserDB(UserDB):
 
     def __init__(self, db_uri, db_name='eduid_actions', collection='chpass'):
         UserDB.__init__(self, db_uri, db_name, collection)
-

--- a/src/eduid_userdb/actions/db.py
+++ b/src/eduid_userdb/actions/db.py
@@ -35,7 +35,6 @@ from typing import Union, Optional, List, Tuple, Dict, Any
 from bson import ObjectId
 from bson.errors import InvalidId
 from pymongo.cursor import Cursor
-from pymongo.results import DeleteResult
 
 from eduid_userdb.actions import Action
 from eduid_userdb.db import BaseDB

--- a/src/eduid_userdb/actions/tou/user.py
+++ b/src/eduid_userdb/actions/tou/user.py
@@ -32,8 +32,6 @@
 
 __author__ = 'eperez'
 
-import bson
-
 from eduid_userdb import User
 from eduid_userdb.exceptions import UserMissingData
 
@@ -57,7 +55,7 @@ class ToUUser(User):
     """
 
     def __init__(self, userid = None, eppn = None, tou = None, data = None,
-                                         raise_on_unknown = True):
+                 raise_on_unknown = True):
         """
         """
         if data is None:

--- a/src/eduid_userdb/actions/tou/userdb.py
+++ b/src/eduid_userdb/actions/tou/userdb.py
@@ -42,4 +42,3 @@ class ToUUserDB(UserDB):
 
     def __init__(self, db_uri, db_name='eduid_actions', collection='tou'):
         UserDB.__init__(self, db_uri, db_name, collection)
-

--- a/src/eduid_userdb/admin/__init__.py
+++ b/src/eduid_userdb/admin/__init__.py
@@ -35,6 +35,7 @@ class RawDb(object):
     *with backups* of the data before and after modification, and an easily searchable
     log detailing all the changes.
     """
+
     def __init__(self, myname=None, backupbase='/root/raw_db_changes'):
         self._client = get_client()
         self._start_time = datetime.datetime.fromtimestamp(int(time.time())).isoformat(sep = '_').replace(':', '')
@@ -129,7 +130,7 @@ class RawDb(object):
         def safe_encode(k, v):
             try:
                 return bson.json_util.dumps({k: v})
-            except:
+            except Exception:
                 sys.stderr.write('Failed encoding key {!r}: {!r}\n\n'.format(k, v))
                 raise
 

--- a/src/eduid_userdb/authninfo.py
+++ b/src/eduid_userdb/authninfo.py
@@ -2,7 +2,6 @@
 
 from __future__ import absolute_import
 
-from bson import ObjectId
 import logging
 
 from eduid_userdb.userdb import BaseDB

--- a/src/eduid_userdb/credentials/base.py
+++ b/src/eduid_userdb/credentials/base.py
@@ -52,6 +52,7 @@ class Credential(VerifiedElement):
     only for credentials until we know we want it for other types of verifed
     elements too.
     """
+
     def __init__(self, data):
         super(Credential, self).__init__(data)
 

--- a/src/eduid_userdb/credentials/fido.py
+++ b/src/eduid_userdb/credentials/fido.py
@@ -155,7 +155,6 @@ class U2F(FidoCredential):
             # Just keep everything that is left as-is
             self._data.update(data)
 
-
     @property
     def key(self):
         """
@@ -279,7 +278,6 @@ class Webauthn(FidoCredential):
                 ))
             # Just keep everything that is left as-is
             self._data.update(data)
-
 
     @property
     def key(self):

--- a/src/eduid_userdb/dashboard/user.py
+++ b/src/eduid_userdb/dashboard/user.py
@@ -177,7 +177,7 @@ class DashboardLegacyUser(object):
 
         :return: bson.ObjectId
         '''
-        if not '_id' in self._mongo_doc:
+        if '_id' not in self._mongo_doc:
             raise UserDBValueError('No user_id in user')
         return self._mongo_doc['_id']
 
@@ -429,7 +429,7 @@ class DashboardLegacyUser(object):
         self._mongo_doc['postalAddress'] = addresses
 
     def retrieve_address(self, request, verified_nin):
-        """ 
+        """
         Get the official postal address for a user
         from the government service,
         remove any previous official address that the user might have,
@@ -530,7 +530,7 @@ class DashboardLegacyUser(object):
             {
             'id': ObjectId('112345678901234567890123'),
             'salt': '$NDNv1H1$9c810d852430b62a9a7c6159d5d64c41c3831846f81b6799b54e1e8922f11545$32$32$',
-            'source' : 'signup', 
+            'source' : 'signup',
             'created_ts' : ISODate('2013-11-28T13:33:44.479Z')
             }
 
@@ -547,7 +547,7 @@ class DashboardLegacyUser(object):
             {
             'id': ObjectId('112345678901234567890123'),
             'salt': '$NDNv1H1$9c810d852430b62a9a7c6159d5d64c41c3831846f81b6799b54e1e8922f11545$32$32$',
-            'source' : 'signup', 
+            'source' : 'signup',
             'created_ts' : ISODate('2013-11-28T13:33:44.479Z')
             }
         This removes any previous list of passwords
@@ -560,7 +560,7 @@ class DashboardLegacyUser(object):
 
     def get_entitlements(self):
         '''
-        Get the user's entitlements as a list of 
+        Get the user's entitlements as a list of
         names within the MACE URN urn:mace:eduid.se:role namespace,
         for example:
             [
@@ -574,7 +574,7 @@ class DashboardLegacyUser(object):
 
     def set_entitlements(self, entitlements):
         '''
-        Set the user's entitlements as a list of 
+        Set the user's entitlements as a list of
         names within the MACE URN urn:mace:eduid.se:role namespace, like:
             [
             'urn:mace:eduid.se:role:admin',

--- a/src/eduid_userdb/dashboard/userdb.py
+++ b/src/eduid_userdb/dashboard/userdb.py
@@ -164,4 +164,3 @@ class UserDBWrapper(UserDB):
                 return al2_urn
 
         return al1_urn
-

--- a/src/eduid_userdb/data_samples.py
+++ b/src/eduid_userdb/data_samples.py
@@ -1,5 +1,5 @@
 '''
-Some data samples, old and new. 
+Some data samples, old and new.
 '''
 
 from datetime import datetime
@@ -25,7 +25,7 @@ OLD_USER_EXAMPLE = {
         'email': 'johnsmith3@example.com',
         'verified': False,
     }],
-    'norEduPersonNIN': ['197801011234',],
+    'norEduPersonNIN': ['197801011234'],
     'postalAddress': [{
         'type': 'home',
         'country': 'SE',
@@ -53,7 +53,7 @@ OLD_USER_EXAMPLE = {
         'id': ObjectId('112345678901234567890123'),
         'salt': '$NDNv1H1$9c810d852430b62a9a7c6159d5d64c41c3831846f81b6799b54e1e8922f11545$32$32$',
         'source': 'signup',
-        'created_ts': datetime.strptime("2013-09-02T10:23:25", "%Y-%m-%dT%H:%M:%S"), 
+        'created_ts': datetime.strptime("2013-09-02T10:23:25", "%Y-%m-%dT%H:%M:%S"),
     }],
     'eduPersonEntitlement': [
         'urn:mace:eduid.se:role:admin',
@@ -97,7 +97,7 @@ NEW_USER_EXAMPLE = {
     'mailAliases': [{
         'email': 'johnsmith@example.com',
         'created_by': 'signup',
-        'created_ts': datetime.strptime("2013-09-02T10:23:25", "%Y-%m-%dT%H:%M:%S"), 
+        'created_ts': datetime.strptime("2013-09-02T10:23:25", "%Y-%m-%dT%H:%M:%S"),
         'verified': True,
         'verified_by': 'signup',
         'verified_ts': datetime.strptime("2013-09-02T10:23:25", "%Y-%m-%dT%H:%M:%S"),
@@ -105,7 +105,7 @@ NEW_USER_EXAMPLE = {
     }, {
         'email': 'johnsmith2@example.com',
         'created_by': 'dashboard',
-        'created_ts': datetime.strptime("2013-09-02T10:23:25", "%Y-%m-%dT%H:%M:%S"), 
+        'created_ts': datetime.strptime("2013-09-02T10:23:25", "%Y-%m-%dT%H:%M:%S"),
         'verified': False,
         'verified_by': 'dashboard',
         'verified_ts': datetime.strptime("2013-09-02T10:23:25", "%Y-%m-%dT%H:%M:%S"),
@@ -113,7 +113,7 @@ NEW_USER_EXAMPLE = {
     }],
     'nins': [{
         'number': '197801011234',
-        'created_ts': datetime.strptime("2013-09-02T10:23:25", "%Y-%m-%dT%H:%M:%S"), 
+        'created_ts': datetime.strptime("2013-09-02T10:23:25", "%Y-%m-%dT%H:%M:%S"),
         'created_by': 'dashboard',
         'verified': True,
         'verified_by': 'dashboard',
@@ -121,7 +121,7 @@ NEW_USER_EXAMPLE = {
         'primary': True,
     }, {
         'number': '197801011235',
-        'created_ts': datetime.strptime("2013-09-02T10:23:25", "%Y-%m-%dT%H:%M:%S"), 
+        'created_ts': datetime.strptime("2013-09-02T10:23:25", "%Y-%m-%dT%H:%M:%S"),
         'created_by': 'dashboard',
         'verified': True,
         'verified_by': 'dashboard',
@@ -130,7 +130,7 @@ NEW_USER_EXAMPLE = {
     }],
     'phone': [{
         'number': '+34609609609',
-        'created_ts': datetime.strptime("2013-09-02T10:23:25", "%Y-%m-%dT%H:%M:%S"), 
+        'created_ts': datetime.strptime("2013-09-02T10:23:25", "%Y-%m-%dT%H:%M:%S"),
         'created_by': 'dashboard',
         'verified': True,
         'verified_by': 'dashboard',
@@ -138,7 +138,7 @@ NEW_USER_EXAMPLE = {
         'primary': True,
     }, {
         'number': '+34 6096096096',
-        'created_ts': datetime.strptime("2013-09-02T10:23:25", "%Y-%m-%dT%H:%M:%S"), 
+        'created_ts': datetime.strptime("2013-09-02T10:23:25", "%Y-%m-%dT%H:%M:%S"),
         'created_by': 'dashboard',
         'verified': False,
         'verified_by': 'dashboard',
@@ -149,7 +149,7 @@ NEW_USER_EXAMPLE = {
         'id': ObjectId('112345678901234567890123'),
         'salt': '$NDNv1H1$9c810d852430b62a9a7c6159d5d64c41c3831846f81b6799b54e1e8922f11545$32$32$',
         'created_by': 'signup',
-        'created_ts': datetime.strptime("2013-09-02T10:23:25", "%Y-%m-%dT%H:%M:%S"), 
+        'created_ts': datetime.strptime("2013-09-02T10:23:25", "%Y-%m-%dT%H:%M:%S"),
     }],
     'entitlements': [
         'urn:mace:eduid.se:role:admin',
@@ -171,7 +171,7 @@ NEW_SIGNUP_USER_EXAMPLE.update({
     'pending_mail_address': {
         'email': 'johnsmith2@example.com',
         'created_by': 'dashboard',
-        'created_ts': datetime.strptime("2013-09-02T10:23:25", "%Y-%m-%dT%H:%M:%S"), 
+        'created_ts': datetime.strptime("2013-09-02T10:23:25", "%Y-%m-%dT%H:%M:%S"),
         'verified': False,
         'verified_by': None,
         'verified_ts': None,

--- a/src/eduid_userdb/db.py
+++ b/src/eduid_userdb/db.py
@@ -2,15 +2,13 @@ from __future__ import absolute_import
 
 import copy
 import warnings
-from typing import Optional, Mapping, Union, List, Any
+from typing import Optional, Mapping, Union, List
 
 import pymongo
 import logging
 
 from bson import ObjectId
-from pymongo.cursor import Cursor
 from pymongo.errors import PyMongoError
-from pymongo.results import DeleteResult
 from pymongo.uri_parser import parse_uri
 
 from eduid_userdb.exceptions import DocumentDoesNotExist, MultipleDocumentsReturned
@@ -356,4 +354,3 @@ class BaseDB(object):
 
     def close(self):
         self._db.close()
-

--- a/src/eduid_userdb/deprecation.py
+++ b/src/eduid_userdb/deprecation.py
@@ -35,6 +35,7 @@ import inspect
 from six import string_types
 from functools import wraps
 
+
 # https://stackoverflow.com/questions/2536307/how-do-i-deprecate-python-functions/40301488#40301488
 def deprecated(reason):
     """
@@ -107,4 +108,3 @@ def deprecated(reason):
 
     else:
         raise TypeError(repr(type(reason)))
-

--- a/src/eduid_userdb/event.py
+++ b/src/eduid_userdb/event.py
@@ -124,7 +124,7 @@ class Event(Element):
         self._data['event_id'] = value
 
     # -----------------------------------------------------------------
-    def to_dict(self, mixed_format: bool=False) -> Dict[str, Any]:
+    def to_dict(self, mixed_format: bool = False) -> Dict[str, Any]:
         """
         Convert Element to a dict, that can be used to reconstruct the Element later.
 
@@ -152,7 +152,7 @@ class EventList(ElementList):
     :type event_class: object
     """
 
-    def __init__(self, events, raise_on_unknown=True, event_class: Type[Event]=Event):
+    def __init__(self, events, raise_on_unknown=True, event_class: Type[Event] = Event):
         self._event_class = event_class
         ElementList.__init__(self, elements=[])
 
@@ -182,7 +182,7 @@ class EventList(ElementList):
             raise DuplicateElementViolation("Event {!s} already in list".format(event.key))
         super(EventList, self).add(event)
 
-    def to_list_of_dicts(self, mixed_format: bool=False) -> List[Dict[str, Any]]:
+    def to_list_of_dicts(self, mixed_format: bool = False) -> List[Dict[str, Any]]:
         """
         Get the elements in a serialized format that can be stored in MongoDB.
 
@@ -191,7 +191,7 @@ class EventList(ElementList):
         return [this.to_dict(mixed_format=mixed_format) for this in self._elements if isinstance(this, Event)]
 
 
-def event_from_dict(data: Dict[str, Any], raise_on_unknown: bool=True):
+def event_from_dict(data: Dict[str, Any], raise_on_unknown: bool = True):
     """
     Create an Event instance (probably really a subclass of Event) from a dict.
 

--- a/src/eduid_userdb/exceptions.py
+++ b/src/eduid_userdb/exceptions.py
@@ -10,6 +10,7 @@ class EduIDDBError(Exception):
     :param reason: Reason for exception (typically a string)
     :type reason: object
     """
+
     def __init__(self, reason):
         Exception.__init__(self)
         self.reason = reason

--- a/src/eduid_userdb/idp/db.py
+++ b/src/eduid_userdb/idp/db.py
@@ -37,7 +37,6 @@
 User and user database module.
 """
 from bson import ObjectId
-from six import string_types
 import logging
 from typing import Optional, Union
 

--- a/src/eduid_userdb/locked_identity.py
+++ b/src/eduid_userdb/locked_identity.py
@@ -100,6 +100,7 @@ class LockedIdentityList(ElementList):
     :param locked_identities: List of LockedIdentityElements
     :type locked_identities: [dict | Element]
     """
+
     def __init__(self, locked_identities):
         elements = []
         for item in locked_identities:

--- a/src/eduid_userdb/mail.py
+++ b/src/eduid_userdb/mail.py
@@ -48,6 +48,7 @@ class MailAddress(PrimaryElement):
     :type data: dict
     :type raise_on_unknown: bool
     """
+
     def __init__(self, email=None, application=None, verified=False, created_ts=None, primary=None,
                  data=None, raise_on_unknown=True):
         data_in = data

--- a/src/eduid_userdb/proofing/db.py
+++ b/src/eduid_userdb/proofing/db.py
@@ -33,11 +33,10 @@
 import datetime
 import logging
 from operator import itemgetter
-from typing import Optional, Type, TypeVar, ClassVar
+from typing import Optional, Type, TypeVar
 
 from eduid_userdb.db import BaseDB
 from eduid_userdb.exceptions import DocumentOutOfSync
-from eduid_userdb.exceptions import MultipleDocumentsReturned
 from eduid_userdb.proofing import PhoneProofingState, OrcidProofingState
 from eduid_userdb.proofing import ProofingUser, LetterProofingState, OidcProofingState, EmailProofingState
 from eduid_userdb.proofing.state import ProofingState

--- a/src/eduid_userdb/proofing/element.py
+++ b/src/eduid_userdb/proofing/element.py
@@ -60,6 +60,7 @@ class ProofingElement(VerifiedElement):
 
     :type data: dict
     """
+
     def __init__(self, application=None, created_ts=None,
                  verified=False, verified_by=None, verified_ts=None,
                  verification_code=None, data=None):
@@ -119,6 +120,7 @@ class NinProofingElement(ProofingElement):
 
     :type data: dict
     """
+
     def __init__(self, number=None, application=None, created_ts=None,
                  verified=False, verification_code=None, data=None):
 
@@ -127,8 +129,8 @@ class NinProofingElement(ProofingElement):
             number = data.pop('number')
 
         super(NinProofingElement, self).__init__(application=application,
-                                                   created_ts=created_ts, verified=verified,
-                                                   verification_code=verification_code, data=data)
+                                                 created_ts=created_ts, verified=verified,
+                                                 verification_code=verification_code, data=data)
         self.number = number
 
     @property

--- a/src/eduid_userdb/proofing/state.py
+++ b/src/eduid_userdb/proofing/state.py
@@ -40,7 +40,7 @@ import datetime
 
 from dataclasses import dataclass, asdict
 
-from typing import Optional, Mapping, MutableMapping, Iterable, Set
+from typing import Optional, Mapping, MutableMapping, Set
 
 from eduid_userdb.exceptions import UserDBValueError
 from eduid_userdb.proofing.element import NinProofingElement, SentLetterElement
@@ -48,7 +48,6 @@ from eduid_userdb.proofing.element import EmailProofingElement, PhoneProofingEle
 
 
 __author__ = 'lundberg'
-
 
 
 @dataclass()

--- a/src/eduid_userdb/reset_password/db.py
+++ b/src/eduid_userdb/reset_password/db.py
@@ -32,7 +32,6 @@
 #
 from typing import Optional, Mapping, Dict, Any
 
-from pymongo.errors import DuplicateKeyError
 from eduid_userdb.db import BaseDB
 from eduid_userdb.user import User
 from eduid_userdb.userdb import UserDB
@@ -85,7 +84,7 @@ class ResetPasswordStateDB(BaseDB):
         """
         spec = {'email_code.code': email_code}
         states = list(self._get_documents_by_filter(spec,
-                                            raise_on_missing=raise_on_missing))
+                      raise_on_missing=raise_on_missing))
 
         if len(states) == 0:
             return None

--- a/src/eduid_userdb/reset_password/element.py
+++ b/src/eduid_userdb/reset_password/element.py
@@ -52,7 +52,6 @@ class CodeElement(Element):
         self.code = code
         self.is_verified = verified
 
-
     @property
     def key(self) -> str:
         """Get element key."""
@@ -109,4 +108,3 @@ class CodeElement(Element):
         if isinstance(code_or_element, CodeElement):
             return code_or_element
         raise ValueError(f'Can\'t create CodeElement from input: {code_or_element}')
-

--- a/src/eduid_userdb/reset_password/state.py
+++ b/src/eduid_userdb/reset_password/state.py
@@ -57,7 +57,7 @@ class ResetPasswordState(object):
         # eppn
         self._data['eduPersonPrincipalName'] = self._data_in.pop('eduPersonPrincipalName')
 
-        #method
+        # method
         self._data['method'] = self._data_in.pop('method', None)
 
         # extra security alternatives

--- a/src/eduid_userdb/security/db.py
+++ b/src/eduid_userdb/security/db.py
@@ -32,7 +32,6 @@
 #
 from __future__ import absolute_import
 
-from pymongo.errors import DuplicateKeyError
 from eduid_userdb.db import BaseDB
 from eduid_userdb.userdb import UserDB
 from eduid_userdb.exceptions import DocumentOutOfSync, MultipleDocumentsReturned

--- a/src/eduid_userdb/security/element.py
+++ b/src/eduid_userdb/security/element.py
@@ -26,7 +26,6 @@ class CodeElement(Element):
         self.code = code
         self.is_verified = verified
 
-
     @property
     def key(self) -> str:
         """Get element key."""
@@ -83,4 +82,3 @@ class CodeElement(Element):
         if isinstance(code_or_element, CodeElement):
             return code_or_element
         raise ValueError(f'Can\'t create CodeElement from input: {code_or_element}')
-

--- a/src/eduid_userdb/security/state.py
+++ b/src/eduid_userdb/security/state.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import
 
 import bson
 import copy
-import datetime
 from six import string_types
 
 from eduid_userdb.element import _set_something_ts

--- a/src/eduid_userdb/testing.py
+++ b/src/eduid_userdb/testing.py
@@ -44,7 +44,6 @@ import subprocess
 import time
 import unittest
 from copy import deepcopy
-from datetime import date, timedelta
 
 import pymongo
 from bson import ObjectId
@@ -58,8 +57,8 @@ logger = logging.getLogger(__name__)
 MONGO_URI_AM_TEST = 'mongodb://localhost:27017/eduid_userdb_test'
 MONGO_URI_TEST = 'mongodb://localhost:27017/eduid_dashboard_test'
 
-#eduid_userdb.db.DEFAULT_MONGODB_URI = MONGO_URI_AM_TEST
-#eduid_userdb.db.DEFAULT_MONGODB_NAME = 'eduid_userdb_test'
+# eduid_userdb.db.DEFAULT_MONGODB_URI = MONGO_URI_AM_TEST
+# eduid_userdb.db.DEFAULT_MONGODB_NAME = 'eduid_userdb_test'
 
 
 MOCKED_USER_STANDARD = {
@@ -71,11 +70,11 @@ MOCKED_USER_STANDARD = {
                          'verified': True,
                          'primary': True,
                          }],
-    #'photo': 'https://pointing.to/your/photo',
+    # 'photo': 'https://pointing.to/your/photo',
     'preferredLanguage': 'en',
     'eduPersonPrincipalName': 'hubba-bubba',
-    #'modified_ts': datetime.strptime("2013-09-02T10:23:25", "%Y-%m-%dT%H:%M:%S"),
-    #'terminated': None,
+    # 'modified_ts': datetime.strptime("2013-09-02T10:23:25", "%Y-%m-%dT%H:%M:%S"),
+    # 'terminated': None,
     'eduPersonEntitlement': [
         'urn:mace:eduid.se:role:admin',
         'urn:mace:eduid.se:role:student',
@@ -106,22 +105,23 @@ MOCKED_USER_STANDARD = {
         'id': ObjectId('112345678901234567890123'),
         'salt': '$NDNv1H1$9c810d852430b62a9a7c6159d5d64c41c3831846f81b6799b54e1e8922f11545$32$32$',
     }],
-    #'postalAddress': [{
+    # 'postalAddress': [{
     #    'type': 'home',
     #    'country': 'SE',
     #    'address': "Long street, 48",
     #    'postalCode': "123456",
     #    'locality': "Stockholm",
     #    'verified': True,
-    #}, {
+    # }, {
     #    'type': 'work',
     #    'country': 'ES',
     #    'address': "Calle Ancha, 49",
     #    'postalCode': "123456",
     #    'locality': "Punta Umbria",
     #    'verified': False,
-    #}],
+    # }],
 }
+
 
 class MockedUserDB(UserDB):
     """
@@ -338,6 +338,6 @@ class MongoTestCase(unittest.TestCase):
         self.amdb.close()
         super(MongoTestCase, self).tearDown()
 
-    #def mongodb_uri(self, dbname):
+    # def mongodb_uri(self, dbname):
     #    self.assertIsNotNone(dbname)
     #    return self.tmp_db.uri + '/' + dbname

--- a/src/eduid_userdb/tests/test_action.py
+++ b/src/eduid_userdb/tests/test_action.py
@@ -16,9 +16,9 @@ _action_dict = {
     'preference': 100,
     'params': {
         'version': '2014-v2'
-        },
+    },
     'result': None,
-    }
+}
 
 _action_dict_userid = {
     '_id': bson.ObjectId('234567890123456789012301'),
@@ -28,9 +28,9 @@ _action_dict_userid = {
     'preference': 100,
     'params': {
         'version': '2014-v2'
-        },
+    },
     'result': None,
-    }
+}
 
 
 class TestAction(TestCase):
@@ -119,7 +119,7 @@ class TestAction(TestCase):
         action_dict = copy.copy(_action_dict)
         action_dict['ho'] = 'ho ho'
         with self.assertRaises(eduid_userdb.exceptions.ActionHasUnknownData):
-            action = Action(data=action_dict)
+            Action(data=action_dict)
 
     def test_action_dont_raise_on_unknown(self):
         action_dict = copy.copy(_action_dict)

--- a/src/eduid_userdb/tests/test_actions_db.py
+++ b/src/eduid_userdb/tests/test_actions_db.py
@@ -30,7 +30,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
-from copy import deepcopy
 from bson import ObjectId
 from eduid_userdb.actions.db import ActionDB
 from eduid_userdb.testing import MongoTestCase
@@ -46,42 +45,42 @@ EPPN4 = 'hussa-sussa'
 
 
 DUMMY_ACTION = {
-        '_id': ObjectId('111111111111111111111111'),
-        'eppn': EPPN3,
-        'action': 'dummy',
-        'preference': 200, 
-        'params': {
-            }
-        }
+    '_id': ObjectId('111111111111111111111111'),
+    'eppn': EPPN3,
+    'action': 'dummy',
+    'preference': 200,
+    'params': {
+    }
+}
 
 TOU_ACTION = {
-        '_id': ObjectId('222222222222222222222222'),
-        'eppn': EPPN3,  # same eppn as DUMMY_ACTION
-        'action': 'tou',
-        'preference': 100,
-        'params': {
-            'version': 'test-version'
-            }
-        }
+    '_id': ObjectId('222222222222222222222222'),
+    'eppn': EPPN3,  # same eppn as DUMMY_ACTION
+    'action': 'tou',
+    'preference': 100,
+    'params': {
+        'version': 'test-version'
+    }
+}
 
 DUMMY_ACTION_USERID = {
-        '_id': ObjectId('111111111111111111111111'),
-        'user_oid': ObjectId(USERID3),
-        'action': 'dummy',
-        'preference': 200, 
-        'params': {
-            }
-        }
+    '_id': ObjectId('111111111111111111111111'),
+    'user_oid': ObjectId(USERID3),
+    'action': 'dummy',
+    'preference': 200,
+    'params': {
+    }
+}
 
 TOU_ACTION_USERID = {
-        '_id': ObjectId('222222222222222222222222'),
-        'user_oid': ObjectId(USERID3),  # same user_oid as DUMMY_ACTION
-        'action': 'tou',
-        'preference': 100,
-        'params': {
-            'version': 'test-version'
-            }
-        }
+    '_id': ObjectId('222222222222222222222222'),
+    'user_oid': ObjectId(USERID3),  # same user_oid as DUMMY_ACTION
+    'action': 'tou',
+    'preference': 100,
+    'params': {
+        'version': 'test-version'
+    }
+}
 
 
 class TestActionsDB(MongoTestCase):
@@ -118,7 +117,7 @@ class TestActionsDB(MongoTestCase):
         action.result = {'test': True}
         self.actionsdb.update_action(action)
         # Saving a result on the action should make get_next_action advance to the next one
-        next_action = self.actionsdb.get_next_action(EPPN3)
+        self.actionsdb.get_next_action(EPPN3)
 
 
 class TestActionsDBUserid(MongoTestCase):
@@ -155,5 +154,4 @@ class TestActionsDBUserid(MongoTestCase):
         action.result = {'test': True}
         self.actionsdb.update_action(action)
         # Saving a result on the action should make get_next_action advance to the next one
-        next_action = self.actionsdb.get_next_action(USERID3)
-
+        self.actionsdb.get_next_action(USERID3)

--- a/src/eduid_userdb/tests/test_credentials.py
+++ b/src/eduid_userdb/tests/test_credentials.py
@@ -9,12 +9,12 @@ from eduid_userdb.credentials import CredentialList, U2F, Password
 
 __author__ = 'lundberg'
 
-#{'passwords': {
+# {'passwords': {
 #    'id': password_id,
 #    'salt': salt,
 #    'source': 'signup',
 #    'created_ts': datetime.datetime.utcnow(),
-#}}
+# }}
 
 _one_dict = {
     'credential_id': '111111111111111111111111',
@@ -38,6 +38,7 @@ _four_dict = {
     'keyhandle': 'firstU2FElement',
     'public_key': 'foo',
 }
+
 
 def _keyid(key):
     return 'sha256:' + sha256(key['keyhandle'].encode('utf-8') +

--- a/src/eduid_userdb/tests/test_dashboard_user.py
+++ b/src/eduid_userdb/tests/test_dashboard_user.py
@@ -18,8 +18,8 @@ class TestUser(TestCase):
         user.set_mail_aliases([])
         user.set_mail_aliases(
             [{
-            'email': 'testmail@example.com',
-            'verified': False,
+                'email': 'testmail@example.com',
+                'verified': False,
             }]
         )
 

--- a/src/eduid_userdb/tests/test_db.py
+++ b/src/eduid_userdb/tests/test_db.py
@@ -59,7 +59,7 @@ class TestMongoDB(TestCase):
         mdb = db.MongoDB(uri, db_name='testdb', connection_factory=DummyConnection)
         conn = mdb.get_connection()
         self.assertIsNotNone(conn)
-        database = mdb.get_database()
+        _ = mdb.get_database()
         self.assertEqual(mdb._db_uri, uri)
         self.assertEqual(mdb._database_name, 'testdb')
         self.assertEqual(mdb.sanitized_uri, 'mongodb://john:secret@db.example.com:1111/testdb')

--- a/src/eduid_userdb/tests/test_event.py
+++ b/src/eduid_userdb/tests/test_event.py
@@ -158,24 +158,24 @@ class TestEventList(TestCase):
 
     def test_loading_duplicate_tou_events(self):
         data = [
-                {
-                        "event_id" : bson.ObjectId("5699fdbed300e400155be719"),
-                        "version" : "2014-v1",
-                        "created_ts" : datetime.datetime.fromisoformat("2016-01-16T08:22:22.520"),
-                        "created_by" : "signup"
-                },
-                {
-                        "event_id" : bson.ObjectId("581c3084df7c670064b583d6"),
-                        "version" : "2016-v1",
-                        "created_ts" : datetime.datetime.fromisoformat("2016-11-04T06:53:56.217"),
-                        "created_by" : "eduid_tou_plugin"
-                },
-                {
-                        "event_id" : bson.ObjectId("581c308e70971c006488d7d7"),
-                        "version" : "2016-v1",
-                        "created_ts" : datetime.datetime.fromisoformat("2016-11-04T06:54:06.676"),
-                        "created_by" : "eduid_tou_plugin"
-                }
+            {
+                "event_id": bson.ObjectId("5699fdbed300e400155be719"),
+                "version": "2014-v1",
+                "created_ts": datetime.datetime.fromisoformat("2016-01-16T08:22:22.520"),
+                "created_by": "signup"
+            },
+            {
+                "event_id": bson.ObjectId("581c3084df7c670064b583d6"),
+                "version": "2016-v1",
+                "created_ts": datetime.datetime.fromisoformat("2016-11-04T06:53:56.217"),
+                "created_by": "eduid_tou_plugin"
+            },
+            {
+                "event_id": bson.ObjectId("581c308e70971c006488d7d7"),
+                "version": "2016-v1",
+                "created_ts": datetime.datetime.fromisoformat("2016-11-04T06:54:06.676"),
+                "created_by": "eduid_tou_plugin"
+            }
         ]
         el = ToUList(data)
         self.assertEqual(el.count, 2)

--- a/src/eduid_userdb/tests/test_mail.py
+++ b/src/eduid_userdb/tests/test_mail.py
@@ -279,4 +279,3 @@ class TestMailAddress(TestCase):
             this.created_ts = None
         with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
             this.created_ts = True
-

--- a/src/eduid_userdb/tests/test_nin.py
+++ b/src/eduid_userdb/tests/test_nin.py
@@ -149,7 +149,7 @@ class TestNinList(TestCase):
         one = copy.deepcopy(_one_dict)
         one['verified'] = False
         with self.assertRaises(eduid_userdb.element.PrimaryElementViolation):
-            this = NinList([one])
+            _ = NinList([one])
 
 
 class TestNin(TestCase):
@@ -280,4 +280,3 @@ class TestNin(TestCase):
             this.created_ts = None
         with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
             this.created_ts = True
-

--- a/src/eduid_userdb/tests/test_password.py
+++ b/src/eduid_userdb/tests/test_password.py
@@ -124,18 +124,18 @@ class TestChpassUser(TestCase):
         one = copy.deepcopy(_one_dict)
         password = Password(data = one, raise_on_unknown = False)
         with self.assertRaises(UserMissingData):
-            user = ChpassUser(passwords=[password])
+            _ = ChpassUser(passwords=[password])
 
     def test_missing_tou(self):
         with self.assertRaises(UserMissingData):
-            user = ChpassUser(userid=USERID)
+            _ = ChpassUser(userid=USERID)
 
     def test_unknown_data(self):
         one = copy.deepcopy(_one_dict)
         password = Password(data = one, raise_on_unknown = False)
         data = dict(_id=USERID, passwords=[password], foo='bar')
         with self.assertRaises(UserHasUnknownData):
-            user = ChpassUser(data=data)
+            _ = ChpassUser(data=data)
 
     def test_unknown_data_dont_raise(self):
         one = copy.deepcopy(_one_dict)

--- a/src/eduid_userdb/tests/test_phone.py
+++ b/src/eduid_userdb/tests/test_phone.py
@@ -186,7 +186,7 @@ class TestPhoneNumberList(TestCase):
         one = copy.deepcopy(_one_dict)
         one['verified'] = False
         with self.assertRaises(eduid_userdb.element.PrimaryElementViolation):
-            this = PhoneNumberList([one])
+            _ = PhoneNumberList([one])
 
 
 class TestPhoneNumber(TestCase):
@@ -321,4 +321,3 @@ class TestPhoneNumber(TestCase):
             this.created_ts = None
         with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
             this.created_ts = True
-

--- a/src/eduid_userdb/tests/test_profile.py
+++ b/src/eduid_userdb/tests/test_profile.py
@@ -79,4 +79,3 @@ class ProfileTest(TestCase):
 
         with self.assertRaises(DuplicateElementViolation):
             ProfileList([profile, profile2])
-

--- a/src/eduid_userdb/tests/test_proofing.py
+++ b/src/eduid_userdb/tests/test_proofing.py
@@ -68,7 +68,7 @@ class ProofingStateTest(TestCase):
                                     modified_ts=None,
                                     proofing_letter=SentLetterElement(data={}))
         state.proofing_letter.address = ADDRESS
-        x = state.proofing_letter.to_dict()
+        _ = state.proofing_letter.to_dict()
         state_dict = state.to_dict()
         self.assertEqual(sorted(state_dict.keys()), ['_id', 'eduPersonPrincipalName', 'modified_ts', 'nin',
                                                      'proofing_letter'])

--- a/src/eduid_userdb/tests/test_resetpw.py
+++ b/src/eduid_userdb/tests/test_resetpw.py
@@ -29,13 +29,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 #
-import bson
-from datetime import datetime
-
-import eduid_userdb
 from eduid_userdb.testing import MongoTestCase
-from eduid_userdb import User
-from eduid_userdb.reset_password import ResetPasswordState
 from eduid_userdb.reset_password import ResetPasswordEmailState
 from eduid_userdb.reset_password import ResetPasswordEmailAndPhoneState
 from eduid_userdb.reset_password import ResetPasswordStateDB
@@ -93,10 +87,10 @@ class TestResetPasswordStateDB(MongoTestCase):
                                               email_code="dummy-code")
 
         email_state.extra_security = {'phone_numbers': [
-                                        {'number': '+99999999999',
-                                         'primary': True,
-                                         'verified': True}
-                                            ]}
+                                      {'number': '+99999999999',
+                                       'primary': True,
+                                       'verified': True}
+                                      ]}
         self.resetpw_db.save(email_state)
 
         state = self.resetpw_db.get_state_by_eppn("hubba-bubba")

--- a/src/eduid_userdb/tests/test_support_models.py
+++ b/src/eduid_userdb/tests/test_support_models.py
@@ -1,8 +1,7 @@
 from eduid_userdb.data_samples import (NEW_USER_EXAMPLE,
-                                      NEW_SIGNUP_USER_EXAMPLE,
-                                      NEW_COMPLETED_SIGNUP_USER_EXAMPLE,
-                                      NEW_DASHBOARD_USER_EXAMPLE)
-from eduid_userdb.data_samples import OLD_USER_EXAMPLE, OLD_VERIFICATIONS_EXAMPLE
+                                       NEW_SIGNUP_USER_EXAMPLE,
+                                       NEW_COMPLETED_SIGNUP_USER_EXAMPLE)
+from eduid_userdb.data_samples import OLD_USER_EXAMPLE
 from eduid_userdb import User
 from eduid_userdb.signup import SignupUser
 from eduid_userdb.support import models

--- a/src/eduid_userdb/tests/test_tou.py
+++ b/src/eduid_userdb/tests/test_tou.py
@@ -159,17 +159,17 @@ class TestTouUser(TestCase):
         one = copy.deepcopy(_one_dict)
         tou = ToUEvent(data = one, raise_on_unknown = False)
         with self.assertRaises(UserMissingData):
-            user = ToUUser(tou=[tou], userid=USERID)
+            _ = ToUUser(tou=[tou], userid=USERID)
 
     def test_missing_userid(self):
         one = copy.deepcopy(_one_dict)
         tou = ToUEvent(data = one, raise_on_unknown = False)
         with self.assertRaises(UserMissingData):
-            user = ToUUser(tou=[tou], eppn=EPPN)
+            _ = ToUUser(tou=[tou], eppn=EPPN)
 
     def test_missing_tou(self):
         with self.assertRaises(UserMissingData):
-            user = ToUUser(eppn=EPPN, userid=USERID)
+            _ = ToUUser(eppn=EPPN, userid=USERID)
 
     def test_unknown_data(self):
         one = copy.deepcopy(_one_dict)
@@ -178,7 +178,7 @@ class TestTouUser(TestCase):
         userdata['tou'] = [tou]
         userdata['foo'] = 'bar'
         with self.assertRaises(UserHasUnknownData):
-            user = ToUUser(data=userdata)
+            _ = ToUUser(data=userdata)
 
     def test_unknown_data_dont_raise(self):
         one = copy.deepcopy(_one_dict)

--- a/src/eduid_userdb/tests/test_u2f.py
+++ b/src/eduid_userdb/tests/test_u2f.py
@@ -10,12 +10,12 @@ from eduid_userdb.credentials import CredentialList, U2F
 
 __author__ = 'lundberg'
 
-#{'passwords': {
+# {'passwords': {
 #    'id': password_id,
 #    'salt': salt,
 #    'source': 'signup',
 #    'created_ts': datetime.datetime.utcnow(),
-#}}
+# }}
 
 _one_dict = {
     'version': 'U2F_V2',
@@ -35,6 +35,7 @@ _three_dict = {
     'keyhandle': 'thirdU2FElement',
     'public_key': 'foo',
 }
+
 
 def _keyid(key):
     return 'sha256:' + sha256(key['keyhandle'].encode('utf-8') +
@@ -128,7 +129,6 @@ class TestU2F(TestCase):
         self.assertEqual(this.proofing_method, None)
         with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
             this.proofing_method = False
-
 
     def test_proofing_version(self):
         this = self.three.find(_keyid(_three_dict))

--- a/src/eduid_userdb/tests/test_user.py
+++ b/src/eduid_userdb/tests/test_user.py
@@ -13,6 +13,7 @@ from eduid_userdb.credentials import METHOD_SWAMID_AL2_MFA
 
 __author__ = 'ft'
 
+
 def _keyid(kh):
     return 'sha256:' + sha256(kh.encode('utf-8')).hexdigest()
 
@@ -245,13 +246,13 @@ class TestUser(TestCase):
         data = {u'_id': ObjectId(),
                 u'eduPersonPrincipalName': u'test-test',
                 u'mailAliases': [{u'email': mail,
-                u'verified': True,
-                u'csrf': u'6ae1d4e95305b72318a683883e70e3b8e302cd75'}],
+                                  u'verified': True,
+                                  u'csrf': u'6ae1d4e95305b72318a683883e70e3b8e302cd75'}],
                 u'passwords': [{u'created_ts': datetime.datetime(2014, 9, 4, 8, 57, 7, 362000),
                                 u'credential_id': str(ObjectId()),
                                 u'salt': u'salt',
                                 u'source': u'dashboard'}],
-               }
+                }
         user = User(data)
         self.assertEqual(mail, user.mail_addresses.primary.email)
 
@@ -307,13 +308,13 @@ class TestUser(TestCase):
                 u'mail': u'test@gmail.com',
                 u'mailAliases': [{u'email': u'test@gmail.com', u'verified': True}],
                 u'phone': [{u'csrf': u'47d42078719b8377db622c3ff85b94840b483c92',
-                             u'number': number1,
-                             u'primary': False,
-                             u'verified': False},
-                            {u'csrf': u'47d42078719b8377db622c3ff85b94840b483c92',
-                             u'number': number2,
-                             u'primary': False,
-                             u'verified': False}],
+                            u'number': number1,
+                            u'primary': False,
+                            u'verified': False},
+                           {u'csrf': u'47d42078719b8377db622c3ff85b94840b483c92',
+                            u'number': number2,
+                            u'primary': False,
+                            u'verified': False}],
                 u'passwords': [{u'created_ts': datetime.datetime(2014, 6, 29, 17, 52, 37, 830000),
                                 u'credential_id': str(ObjectId()),
                                 u'salt': u'$NDNv1H1$foo$32$32$',
@@ -337,13 +338,13 @@ class TestUser(TestCase):
                 u'mail': u'test@gmail.com',
                 u'mailAliases': [{u'email': u'test@gmail.com', u'verified': True}],
                 u'phone': [{u'csrf': u'47d42078719b8377db622c3ff85b94840b483c92',
-                             u'number': number1,
-                             u'primary': False,
-                             u'verified': False},
-                            {u'csrf': u'47d42078719b8377db622c3ff85b94840b483c92',
-                             u'number': number2,
-                             u'primary': False,
-                             u'verified': True}],
+                            u'number': number1,
+                            u'primary': False,
+                            u'verified': False},
+                           {u'csrf': u'47d42078719b8377db622c3ff85b94840b483c92',
+                            u'number': number2,
+                            u'primary': False,
+                            u'verified': True}],
                 u'passwords': [{u'created_ts': datetime.datetime(2014, 6, 29, 17, 52, 37, 830000),
                                 u'credential_id': str(ObjectId()),
                                 u'salt': u'$NDNv1H1$foo$32$32$',
@@ -565,11 +566,11 @@ class TestUser(TestCase):
     def test_both_mobile_and_phone(self):
         """ Test user that has both 'mobile' and 'phone' """
         phone = [{'number': '+4673123', 'primary': True, 'verified': True},
-                {'created_by': 'phone',
-                 'created_ts': datetime.datetime.utcnow(),
-                 'number': '+4670999',
-                 'primary': False,
-                 'verified': False}]
+                 {'created_by': 'phone',
+                  'created_ts': datetime.datetime.utcnow(),
+                  'number': '+4670999',
+                  'primary': False,
+                  'verified': False}]
         user = User(data={
             '_id': ObjectId(),
             'eduPersonPrincipalName': 'test-test',

--- a/src/eduid_userdb/tests/test_userdb.py
+++ b/src/eduid_userdb/tests/test_userdb.py
@@ -34,7 +34,6 @@ import bson
 from eduid_userdb.testing import MongoTestCase
 import eduid_userdb
 from eduid_userdb import User
-from datetime import datetime
 
 
 class TestUserDB(MongoTestCase):

--- a/src/eduid_userdb/tests/test_webauthn.py
+++ b/src/eduid_userdb/tests/test_webauthn.py
@@ -29,6 +29,7 @@ _three_dict = {
     'attest_obj': 'foo',
 }
 
+
 def _keyid(key):
     return 'sha256:' + sha256(key['keyhandle'].encode('utf-8') +
                               key['credential_data'].encode('utf-8')
@@ -122,7 +123,6 @@ class TestWebauthn(TestCase):
         self.assertEqual(this.proofing_method, None)
         with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
             this.proofing_method = False
-
 
     def test_proofing_version(self):
         this = self.three.find(_keyid(_three_dict))

--- a/src/eduid_userdb/tou.py
+++ b/src/eduid_userdb/tou.py
@@ -47,8 +47,9 @@ class ToUEvent(Event):
     """
     A record of a user's acceptance of a particular version of the Terms of Use.
     """
+
     def __init__(self, version=None, application=None, created_ts=None, modified_ts=None, event_id=None,
-                 data: Optional[Dict[str, Any]]=None, raise_on_unknown=True):
+                 data: Optional[Dict[str, Any]] = None, raise_on_unknown=True):
         data_in = data
         data = copy.copy(data_in)  # to not modify callers data
 

--- a/src/eduid_userdb/user.py
+++ b/src/eduid_userdb/user.py
@@ -59,6 +59,7 @@ class User(object):
     :param data: MongoDB document representing a user
     :type  data: dict
     """
+
     def __init__(self, data: Dict[str, Any], raise_on_unknown: bool = True):
         self._data_in = copy.deepcopy(data)  # to not modify callers data
         self._data_orig = copy.deepcopy(data)  # to not modify callers data

--- a/src/eduid_userdb/userdb.py
+++ b/src/eduid_userdb/userdb.py
@@ -371,7 +371,7 @@ class UserDB(BaseDB):
             error_msg = f'Invalid update operator: {bad_operators}'
             logger.error(error_msg)
             raise eduid_userdb.exceptions.EduIDDBError(error_msg)
-        
+
         updated_doc = self._coll.find_one_and_update(filter=query_filter, update=operations,
                                                      return_document=ReturnDocument.AFTER, upsert=True)
         logger.debug(f'Updated/inserted document: {updated_doc}')


### PR DESCRIPTION
Linter driven cleanup:
* remove unused imports,
* fix (according to pep8) indentation of continuation lines,
* add spaces around infix operators,
* adjust blank lines,
* remove unused local vars,
* and remove trailing whitespace.

Ignoring flake8 rules E501 (80 char wide lines) E251 (no spaces around = when calling functions) and W504 (no infix operators at the end of lines)