### PR TITLE
Allow for db_count to use query and limit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ README = 'eduID User Database interface module'
 if os.path.exists(README_fn):
     README = open(README_fn).read()
 
-version = '0.4.11'
+version = '0.4.12'
 
 install_requires = [
     'pymongo >= 3.6',

--- a/src/eduid_userdb/db.py
+++ b/src/eduid_userdb/db.py
@@ -305,15 +305,18 @@ class BaseDB(object):
             return []
         return docs
 
-    def db_count(self) -> int:
+    def db_count(self, spec: Optional[dict] = None, limit: Optional[int] = None) -> int:
         """
-        Return number of entries in the database.
+        Return number of entries in the collection.
 
-        Used in test cases.
-
-        :return: User count
+        :return: Document count
         """
-        return self._coll.count_documents({})
+        args = {'filter': {}}
+        if spec:
+            args['filter'] = spec
+        if limit:
+            args['limit'] = limit
+        return self._coll.count_documents(**args)
 
     def remove_document(self, spec_or_id: Union[dict, ObjectId]) -> bool:
         """

--- a/src/eduid_userdb/db.py
+++ b/src/eduid_userdb/db.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import copy
 import logging
 import warnings
-from typing import Any, List, Mapping, Optional, Union
+from typing import Any, List, Mapping, Optional, Union, Dict
 
 import pymongo
 from bson import ObjectId
@@ -311,7 +311,7 @@ class BaseDB(object):
 
         :return: Document count
         """
-        args = {'filter': {}}
+        args: Dict[Any, Any] = {'filter': {}}
         if spec:
             args['filter'] = spec
         if limit:

--- a/src/eduid_userdb/tests/test_db.py
+++ b/src/eduid_userdb/tests/test_db.py
@@ -1,5 +1,7 @@
 from unittest import TestCase
 
+from bson import ObjectId
+
 import eduid_userdb.db as db
 from eduid_userdb.testing import MongoTestCase
 
@@ -77,4 +79,11 @@ class TestMongoDB(TestCase):
 
 class TestDB(MongoTestCase):
     def test_db_count(self):
-        self.assertEqual(self.amdb.db_count(), len(list(self.MockedUserDB().all_userdocs())))
+        self.assertEqual(len(list(self.MockedUserDB().all_userdocs())), self.amdb.db_count())
+
+    def test_db_count_limit(self):
+        self.assertEqual(1, self.amdb.db_count(limit=1))
+        self.assertEqual(2, self.amdb.db_count(limit=2))
+
+    def test_db_count_spec(self):
+        self.assertEqual(1, self.amdb.db_count(spec={'_id': ObjectId('012345678901234567890123')}))


### PR DESCRIPTION
This allows for a more efficient way of finding out if a document is in
a collection.