### PR TITLE
Eperez elem init 1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ README = 'eduID User Database interface module'
 if os.path.exists(README_fn):
     README = open(README_fn).read()
 
-version = '0.4.17'
+version = '0.4.18'
 
 install_requires = [
     'pymongo >= 3.6',

--- a/src/eduid_userdb/credentials/base.py
+++ b/src/eduid_userdb/credentials/base.py
@@ -53,8 +53,8 @@ class Credential(VerifiedElement):
     elements too.
     """
 
-    def __init__(self, data):
-        super(Credential, self).__init__(data)
+    def __init__(self, data, called_directly=True):
+        super(Credential, self).__init__(data, called_directly=called_directly)
 
         self.proofing_method = data.pop('proofing_method', None)
         self.proofing_version = data.pop('proofing_version', None)

--- a/src/eduid_userdb/credentials/base.py
+++ b/src/eduid_userdb/credentials/base.py
@@ -36,6 +36,7 @@
 from __future__ import absolute_import
 
 from six import string_types
+from typing import Any, Dict
 
 from eduid_userdb.element import VerifiedElement
 from eduid_userdb.exceptions import UserDBValueError
@@ -53,7 +54,7 @@ class Credential(VerifiedElement):
     elements too.
     """
 
-    def __init__(self, data, called_directly=True):
+    def __init__(self, data: Dict[str, Any], called_directly: bool = True):
         super(Credential, self).__init__(data, called_directly=called_directly)
 
         self.proofing_method = data.pop('proofing_method', None)

--- a/src/eduid_userdb/credentials/base.py
+++ b/src/eduid_userdb/credentials/base.py
@@ -53,8 +53,8 @@ class Credential(VerifiedElement):
     elements too.
     """
 
-    def __init__(self, data, raise_on_unknown=True, called_directly=True):
-        super(Credential, self).__init__(data, raise_on_unknown=raise_on_unknown, called_directly=called_directly)
+    def __init__(self, data, called_directly=True):
+        super(Credential, self).__init__(data, called_directly=called_directly)
 
         self.proofing_method = data.pop('proofing_method', None)
         self.proofing_version = data.pop('proofing_version', None)

--- a/src/eduid_userdb/credentials/base.py
+++ b/src/eduid_userdb/credentials/base.py
@@ -53,8 +53,8 @@ class Credential(VerifiedElement):
     elements too.
     """
 
-    def __init__(self, data, called_directly=True):
-        super(Credential, self).__init__(data, called_directly=called_directly)
+    def __init__(self, data, raise_on_unknown=True, called_directly=True):
+        super(Credential, self).__init__(data, raise_on_unknown=raise_on_unknown, called_directly=called_directly)
 
         self.proofing_method = data.pop('proofing_method', None)
         self.proofing_version = data.pop('proofing_version', None)

--- a/src/eduid_userdb/credentials/base.py
+++ b/src/eduid_userdb/credentials/base.py
@@ -35,8 +35,9 @@
 
 from __future__ import absolute_import
 
-from six import string_types
 from typing import Any, Dict
+
+from six import string_types
 
 from eduid_userdb.element import VerifiedElement
 from eduid_userdb.exceptions import UserDBValueError

--- a/src/eduid_userdb/credentials/base.py
+++ b/src/eduid_userdb/credentials/base.py
@@ -56,7 +56,7 @@ class Credential(VerifiedElement):
     """
 
     def __init__(self, data: Dict[str, Any], called_directly: bool = True):
-        super(Credential, self).__init__(data, called_directly=called_directly)
+        super().__init__(data, called_directly=called_directly)
 
         self.proofing_method = data.pop('proofing_method', None)
         self.proofing_version = data.pop('proofing_version', None)

--- a/src/eduid_userdb/credentials/fido.py
+++ b/src/eduid_userdb/credentials/fido.py
@@ -61,7 +61,7 @@ class FidoCredential(Credential):
 
     def check_unknown_data(self, data: Dict[str, Any]):
         """
-        called when an instance of a subclass is created with `raise_on_unkknown`
+        called when an instance of a subclass is created with `raise_on_unknown`
         """
         leftovers = data.keys()
         if leftovers:

--- a/src/eduid_userdb/credentials/fido.py
+++ b/src/eduid_userdb/credentials/fido.py
@@ -315,7 +315,9 @@ class Webauthn(FidoCredential):
         self._data.update(data)
 
     @classmethod
-    def from_dict(cls: Type[TWebauthnSubclass], data: Dict[str, Any], raise_on_unknown: bool = True) -> TWebauthnSubclass:
+    def from_dict(
+        cls: Type[TWebauthnSubclass], data: Dict[str, Any], raise_on_unknown: bool = True
+    ) -> TWebauthnSubclass:
         """
         Construct user from a data dict.
         """

--- a/src/eduid_userdb/credentials/fido.py
+++ b/src/eduid_userdb/credentials/fido.py
@@ -54,7 +54,7 @@ class FidoCredential(Credential):
 
     def __init__(self, data: Dict[str, Any], called_directly: bool = True):
 
-        Credential.__init__(self, data, called_directly=called_directly)
+        super().__init__(data, called_directly=called_directly)
         self.keyhandle = data.pop('keyhandle')
         self.app_id = data.pop('app_id')
         self.description = data.pop('description', '')
@@ -164,7 +164,7 @@ class U2F(FidoCredential):
                 created_ts=created_ts,
             )
 
-        FidoCredential.__init__(self, data, called_directly=called_directly)
+        super().__init__(data, called_directly=called_directly)
 
         self.version = data.pop('version')
         self.public_key = data.pop('public_key')
@@ -301,7 +301,7 @@ class Webauthn(FidoCredential):
                 created_by=application,
                 created_ts=created_ts,
             )
-        FidoCredential.__init__(self, data, called_directly=called_directly)
+        super().__init__(data, called_directly=called_directly)
 
         self.attest_obj = data.pop('attest_obj', '')
         self.credential_data = data.pop('credential_data', '')

--- a/src/eduid_userdb/credentials/fido.py
+++ b/src/eduid_userdb/credentials/fido.py
@@ -37,7 +37,7 @@ from __future__ import absolute_import
 import copy
 from datetime import datetime
 from hashlib import sha256
-from typing import Any, Dict, Optional, Type, TypeVar
+from typing import Any, Dict, Optional, Type, Union
 
 from six import string_types
 
@@ -128,9 +128,6 @@ class FidoCredential(Credential):
         self._data['description'] = value
 
 
-TU2FSubclass = TypeVar('TU2FSubclass', bound='U2F')
-
-
 class U2F(FidoCredential):
     """
     U2F token authentication credential
@@ -145,7 +142,7 @@ class U2F(FidoCredential):
         attest_cert: Optional[str] = None,
         description: Optional[str] = None,
         application: Optional[str] = None,
-        created_ts: Optional[datetime] = None,
+        created_ts: Optional[Union[datetime, bool]] = None,
         data: Optional[Dict[str, Any]] = None,
         raise_on_unknown: bool = True,
         called_directly: bool = True,
@@ -180,7 +177,7 @@ class U2F(FidoCredential):
         self._data.update(data)
 
     @classmethod
-    def from_dict(cls: Type[TU2FSubclass], data: Dict[str, Any], raise_on_unknown: bool = True) -> TU2FSubclass:
+    def from_dict(cls: Type['U2F'], data: Dict[str, Any], raise_on_unknown: bool = True) -> 'U2F':
         """
         Construct U2F credential from a data dict.
         """
@@ -271,9 +268,6 @@ def u2f_from_dict(data, raise_on_unknown=True):
     return U2F.from_dict(data, raise_on_unknown=raise_on_unknown)
 
 
-TWebauthnSubclass = TypeVar('TWebauthnSubclass', bound='Webauthn')
-
-
 class Webauthn(FidoCredential):
     """
     Webauthn token authentication credential
@@ -281,16 +275,16 @@ class Webauthn(FidoCredential):
 
     def __init__(
         self,
-        keyhandle=None,
-        credential_data=None,
-        app_id=None,
-        attest_obj=None,
-        description=None,
-        application=None,
-        created_ts=None,
-        data=None,
-        raise_on_unknown=True,
-        called_directly=True,
+        keyhandle: Optional[str] = None,
+        credential_data: Optional[str] = None,
+        app_id: Optional[str] = None,
+        attest_obj: Optional[str] = None,
+        description: Optional[str] = None,
+        application: Optional[str] = None,
+        created_ts: Optional[Union[datetime, bool]] = None,
+        data: Optional[Dict[str, Any]] = None,
+        raise_on_unknown: bool = True,
+        called_directly: bool = True,
     ):
         data_in = data
         data = copy.copy(data_in)  # to not modify callers data
@@ -320,10 +314,10 @@ class Webauthn(FidoCredential):
 
     @classmethod
     def from_dict(
-        cls: Type[TWebauthnSubclass], data: Dict[str, Any], raise_on_unknown: bool = True
-    ) -> TWebauthnSubclass:
+        cls: Type['Webauthn'], data: Dict[str, Any], raise_on_unknown: bool = True
+    ) -> 'Webauthn':
         """
-        Construct user from a data dict.
+        Construct Webauthn credential from a data dict.
         """
         return cls(data=data, called_directly=False, raise_on_unknown=raise_on_unknown)
 

--- a/src/eduid_userdb/credentials/fido.py
+++ b/src/eduid_userdb/credentials/fido.py
@@ -313,9 +313,7 @@ class Webauthn(FidoCredential):
         self._data.update(data)
 
     @classmethod
-    def from_dict(
-        cls: Type['Webauthn'], data: Dict[str, Any], raise_on_unknown: bool = True
-    ) -> 'Webauthn':
+    def from_dict(cls: Type['Webauthn'], data: Dict[str, Any], raise_on_unknown: bool = True) -> 'Webauthn':
         """
         Construct Webauthn credential from a data dict.
         """

--- a/src/eduid_userdb/credentials/fido.py
+++ b/src/eduid_userdb/credentials/fido.py
@@ -35,8 +35,9 @@
 from __future__ import absolute_import
 
 import copy
+from datetime import datetime
 from hashlib import sha256
-from typing import Any, Dict, Type, TypeVar
+from typing import Any, Dict, Optional, Type, TypeVar
 
 from six import string_types
 
@@ -51,7 +52,7 @@ class FidoCredential(Credential):
     Token authentication credential
     """
 
-    def __init__(self, data, called_directly=True):
+    def __init__(self, data: Dict[str, Any], called_directly: bool = True):
 
         Credential.__init__(self, data, called_directly=called_directly)
         self.keyhandle = data.pop('keyhandle')
@@ -59,6 +60,9 @@ class FidoCredential(Credential):
         self.description = data.pop('description', '')
 
     def check_unknown_data(self, data: Dict[str, Any]):
+        """
+        called when an instance of a subclass is created with `raise_on_unkknown`
+        """
         leftovers = data.keys()
         if leftovers:
             raise UserHasUnknownData(f'{self.__class__.__name__} {self.key} unknown data: {leftovers}')
@@ -134,17 +138,17 @@ class U2F(FidoCredential):
 
     def __init__(
         self,
-        version=None,
-        keyhandle=None,
-        public_key=None,
-        app_id=None,
-        attest_cert=None,
-        description=None,
-        application=None,
-        created_ts=None,
-        data=None,
-        raise_on_unknown=True,
-        called_directly=True,
+        version: Optional[str] = None,
+        keyhandle: Optional[str] = None,
+        public_key: Optional[str] = None,
+        app_id: Optional[str] = None,
+        attest_cert: Optional[str] = None,
+        description: Optional[str] = None,
+        application: Optional[str] = None,
+        created_ts: Optional[datetime] = None,
+        data: Optional[Dict[str, Any]] = None,
+        raise_on_unknown: bool = True,
+        called_directly: bool = True,
     ):
         data_in = data
         data = copy.copy(data_in)  # to not modify callers data
@@ -178,7 +182,7 @@ class U2F(FidoCredential):
     @classmethod
     def from_dict(cls: Type[TU2FSubclass], data: Dict[str, Any], raise_on_unknown: bool = True) -> TU2FSubclass:
         """
-        Construct user from a data dict.
+        Construct U2F credential from a data dict.
         """
         return cls(data=data, called_directly=False, raise_on_unknown=raise_on_unknown)
 

--- a/src/eduid_userdb/credentials/fido.py
+++ b/src/eduid_userdb/credentials/fido.py
@@ -32,7 +32,7 @@
 #
 # Author : Fredrik Thulin <fredrik@thulin.net>
 #
-from __future__ import absolute_import
+from __future__ import annotations
 
 import copy
 from datetime import datetime
@@ -177,7 +177,7 @@ class U2F(FidoCredential):
         self._data.update(data)
 
     @classmethod
-    def from_dict(cls: Type['U2F'], data: Dict[str, Any], raise_on_unknown: bool = True) -> 'U2F':
+    def from_dict(cls: Type[U2F], data: Dict[str, Any], raise_on_unknown: bool = True) -> U2F:
         """
         Construct U2F credential from a data dict.
         """
@@ -313,7 +313,7 @@ class Webauthn(FidoCredential):
         self._data.update(data)
 
     @classmethod
-    def from_dict(cls: Type['Webauthn'], data: Dict[str, Any], raise_on_unknown: bool = True) -> 'Webauthn':
+    def from_dict(cls: Type[Webauthn], data: Dict[str, Any], raise_on_unknown: bool = True) -> Webauthn:
         """
         Construct Webauthn credential from a data dict.
         """

--- a/src/eduid_userdb/credentials/fido.py
+++ b/src/eduid_userdb/credentials/fido.py
@@ -52,9 +52,9 @@ class FidoCredential(Credential):
     Token authentication credential
     """
 
-    def __init__(self, data, called_directly=True):
+    def __init__(self, data, raise_on_unknown=True, called_directly=True):
 
-        Credential.__init__(self, data, called_directly=called_directly)
+        Credential.__init__(self, data, raise_on_unknown=raise_on_unknown, called_directly=called_directly)
         self.keyhandle = data.pop('keyhandle')
         self.app_id = data.pop('app_id')
         self.description = data.pop('description', '')
@@ -156,7 +156,7 @@ class U2F(FidoCredential):
                 created_ts=created_ts,
             )
 
-        FidoCredential.__init__(self, data, called_directly=called_directly)
+        FidoCredential.__init__(self, data, raise_on_unknown=raise_on_unknown, called_directly=called_directly)
         self.version = data.pop('version')
         self.public_key = data.pop('public_key')
         self.attest_cert = data.pop('attest_cert', '')
@@ -167,13 +167,6 @@ class U2F(FidoCredential):
                 raise UserHasUnknownData('U2F {!r} unknown data: {!r}'.format(self.key, leftovers,))
             # Just keep everything that is left as-is
             self._data.update(data)
-
-    @classmethod
-    def from_dict(cls: Type[TElementSubclass], data: Dict[str, Any], raise_on_unknown: bool = True) -> TElementSubclass:
-        """
-        Construct user from a data dict.
-        """
-        return cls(data=data, raise_on_unknown=raise_on_unknown, called_directly=False)
 
     @property
     def key(self):
@@ -294,7 +287,7 @@ class Webauthn(FidoCredential):
                 created_ts=created_ts,
             )
 
-        FidoCredential.__init__(self, data, called_directly=called_directly)
+        FidoCredential.__init__(self, data, raise_on_unknown=raise_on_unknown, called_directly=called_directly)
         self.attest_obj = data.pop('attest_obj', '')
         self.credential_data = data.pop('credential_data', '')
 
@@ -304,13 +297,6 @@ class Webauthn(FidoCredential):
                 raise UserHasUnknownData('Webauthn {!r} unknown data: {!r}'.format(self.key, leftovers,))
             # Just keep everything that is left as-is
             self._data.update(data)
-
-    @classmethod
-    def from_dict(cls: Type[TElementSubclass], data: Dict[str, Any], raise_on_unknown: bool = True) -> TElementSubclass:
-        """
-        Construct user from a data dict.
-        """
-        return cls(data=data, raise_on_unknown=raise_on_unknown, called_directly=False)
 
     @property
     def key(self):

--- a/src/eduid_userdb/credentials/password.py
+++ b/src/eduid_userdb/credentials/password.py
@@ -55,6 +55,7 @@ class Password(Credential):
         created_ts: Optional[Union[str, bool]] = None,
         data: Optional[dict] = None,
         raise_on_unknown: bool = True,
+        called_directly: bool = True,
     ):
         data_in = data
         data = copy.copy(data_in)  # to not modify callers data
@@ -68,7 +69,7 @@ class Password(Credential):
 
         if 'source' in data:  # TODO: Load and save all users in the database to replace source with created_by
             data['created_by'] = data.pop('source')
-        Credential.__init__(self, data)
+        Credential.__init__(self, data, called_directly=called_directly)
         if 'id' in data:  # TODO: Load and save all users in the database to replace id with credential_id
             data['credential_id'] = data.pop('id')
         self.is_generated = data.pop('is_generated', False)

--- a/src/eduid_userdb/credentials/password.py
+++ b/src/eduid_userdb/credentials/password.py
@@ -36,10 +36,12 @@ from __future__ import absolute_import
 
 import copy
 from typing import Optional, Union
+from typing import Any, Dict, Type
 
 from bson.objectid import ObjectId
 
 from eduid_userdb.credentials import Credential
+from eduid_userdb.element import TElementSubclass
 from eduid_userdb.exceptions import UserDBValueError, UserHasUnknownData
 
 __author__ = 'lundberg'
@@ -82,6 +84,13 @@ class Password(Credential):
                 raise UserHasUnknownData('Password {!r} unknown data: {!r}'.format(self.key, leftovers))
             # Just keep everything that is left as-is
             self._data.update(data)
+
+    @classmethod
+    def from_dict(cls: Type[TElementSubclass], data: Dict[str, Any], raise_on_unknown: bool = True) -> TElementSubclass:
+        """
+        Construct user from a data dict.
+        """
+        return cls(data=data, raise_on_unknown=raise_on_unknown, called_directly=False)
 
     @property
     def key(self) -> str:
@@ -153,4 +162,4 @@ def password_from_dict(data, raise_on_unknown=True):
     :type raise_on_unknown: bool
     :rtype: Password
     """
-    return Password(data=data, raise_on_unknown=raise_on_unknown)
+    return Password.from_dict(data, raise_on_unknown=raise_on_unknown)

--- a/src/eduid_userdb/credentials/password.py
+++ b/src/eduid_userdb/credentials/password.py
@@ -69,7 +69,7 @@ class Password(Credential):
 
         if 'source' in data:  # TODO: Load and save all users in the database to replace source with created_by
             data['created_by'] = data.pop('source')
-        Credential.__init__(self, data, called_directly=called_directly)
+        super().__init__(data, called_directly=called_directly)
         if 'id' in data:  # TODO: Load and save all users in the database to replace id with credential_id
             data['credential_id'] = data.pop('id')
         self.is_generated = data.pop('is_generated', False)

--- a/src/eduid_userdb/credentials/password.py
+++ b/src/eduid_userdb/credentials/password.py
@@ -88,7 +88,7 @@ class Password(Credential):
         cls: Type['Password'], data: Dict[str, Any], raise_on_unknown: bool = True
     ) -> 'Password':
         """
-        Construct user from a data dict.
+        Construct password credential from a data dict.
         """
         return cls(data=data, raise_on_unknown=raise_on_unknown, called_directly=False)
 

--- a/src/eduid_userdb/credentials/password.py
+++ b/src/eduid_userdb/credentials/password.py
@@ -87,7 +87,9 @@ class Password(Credential):
             self._data.update(data)
 
     @classmethod
-    def from_dict(cls: Type[TPasswordSubclass], data: Dict[str, Any], raise_on_unknown: bool = True) -> TPasswordSubclass:
+    def from_dict(
+        cls: Type[TPasswordSubclass], data: Dict[str, Any], raise_on_unknown: bool = True
+    ) -> TPasswordSubclass:
         """
         Construct user from a data dict.
         """

--- a/src/eduid_userdb/credentials/password.py
+++ b/src/eduid_userdb/credentials/password.py
@@ -84,9 +84,7 @@ class Password(Credential):
             self._data.update(data)
 
     @classmethod
-    def from_dict(
-        cls: Type['Password'], data: Dict[str, Any], raise_on_unknown: bool = True
-    ) -> 'Password':
+    def from_dict(cls: Type['Password'], data: Dict[str, Any], raise_on_unknown: bool = True) -> 'Password':
         """
         Construct password credential from a data dict.
         """

--- a/src/eduid_userdb/credentials/password.py
+++ b/src/eduid_userdb/credentials/password.py
@@ -35,8 +35,7 @@
 from __future__ import absolute_import
 
 import copy
-from typing import Optional, Union
-from typing import Any, Dict, Type
+from typing import Any, Dict, Optional, Type, Union
 
 from bson.objectid import ObjectId
 

--- a/src/eduid_userdb/credentials/password.py
+++ b/src/eduid_userdb/credentials/password.py
@@ -35,7 +35,7 @@
 from __future__ import absolute_import
 
 import copy
-from typing import Any, Dict, Optional, Type, TypeVar, Union
+from typing import Any, Dict, Optional, Type, Union
 
 from bson.objectid import ObjectId
 
@@ -43,9 +43,6 @@ from eduid_userdb.credentials import Credential
 from eduid_userdb.exceptions import UserDBValueError, UserHasUnknownData
 
 __author__ = 'lundberg'
-
-
-TPasswordSubclass = TypeVar('TPasswordSubclass', bound='Password')
 
 
 class Password(Credential):
@@ -88,8 +85,8 @@ class Password(Credential):
 
     @classmethod
     def from_dict(
-        cls: Type[TPasswordSubclass], data: Dict[str, Any], raise_on_unknown: bool = True
-    ) -> TPasswordSubclass:
+        cls: Type['Password'], data: Dict[str, Any], raise_on_unknown: bool = True
+    ) -> 'Password':
         """
         Construct user from a data dict.
         """

--- a/src/eduid_userdb/credentials/password.py
+++ b/src/eduid_userdb/credentials/password.py
@@ -35,15 +35,17 @@
 from __future__ import absolute_import
 
 import copy
-from typing import Any, Dict, Optional, Type, Union
+from typing import Any, Dict, Optional, Type, TypeVar, Union
 
 from bson.objectid import ObjectId
 
 from eduid_userdb.credentials import Credential
-from eduid_userdb.element import TElementSubclass
 from eduid_userdb.exceptions import UserDBValueError, UserHasUnknownData
 
 __author__ = 'lundberg'
+
+
+TPasswordSubclass = TypeVar('TPasswordSubclass', bound='Password')
 
 
 class Password(Credential):
@@ -85,7 +87,7 @@ class Password(Credential):
             self._data.update(data)
 
     @classmethod
-    def from_dict(cls: Type[TElementSubclass], data: Dict[str, Any], raise_on_unknown: bool = True) -> TElementSubclass:
+    def from_dict(cls: Type[TPasswordSubclass], data: Dict[str, Any], raise_on_unknown: bool = True) -> TPasswordSubclass:
         """
         Construct user from a data dict.
         """

--- a/src/eduid_userdb/element.py
+++ b/src/eduid_userdb/element.py
@@ -295,7 +295,7 @@ class PrimaryElement(VerifiedElement):
         called_directly: bool = True,
         ignore_data: Optional[List[str]] = None,
     ):
-        VerifiedElement.__init__(self, data, called_directly=called_directly)
+        super().__init__(data, called_directly=called_directly)
 
         self.is_primary = data.pop('primary', False)
 

--- a/src/eduid_userdb/element.py
+++ b/src/eduid_userdb/element.py
@@ -96,7 +96,7 @@ class Element(object):
         created_ts
     """
 
-    def __init__(self, data: Dict[str, Any], called_directly: bool = True):
+    def __init__(self, data: Dict[str, Any], raise_on_unknown: bool = True, called_directly: bool = True, ignore_data: Optional[List[str]] = None):
         if called_directly:
             breakpoint()
             warnings.warn("Element.__init__ called directly", DeprecationWarning)
@@ -113,11 +113,11 @@ class Element(object):
         return '<eduID {!s}: {!r}>'.format(self.__class__.__name__, getattr(self, '_data', None))
 
     @classmethod
-    def from_dict(cls: Type[TElementSubclass], data: Dict[str, Any]) -> TElementSubclass:
+    def from_dict(cls: Type[TElementSubclass], data: Dict[str, Any], raise_on_unknown: bool = True) -> TElementSubclass:
         """
         Construct user from a data dict.
         """
-        return cls(data=data, called_directly=False)
+        return cls(data=data, called_directly=False, raise_on_unknown=raise_on_unknown)
 
     # -----------------------------------------------------------------
     @property
@@ -204,8 +204,8 @@ class VerifiedElement(Element):
         verified_ts
     """
 
-    def __init__(self, data, called_directly=True):
-        Element.__init__(self, data, called_directly=called_directly)
+    def __init__(self, data: Dict[str, Any], raise_on_unknown: bool = True, called_directly: bool = True, ignore_data: Optional[List[str]] = None):
+        Element.__init__(self, data, raise_on_unknown=raise_on_unknown, called_directly=called_directly, ignore_data=ignore_data)
         # Remove deprecated verification_code from VerifiedElement
         data.pop('verification_code', None)
         self.is_verified = data.pop('verified', False)
@@ -282,8 +282,8 @@ class PrimaryElement(VerifiedElement):
     :type raise_on_unknown: bool
     """
 
-    def __init__(self, data, raise_on_unknown=True, called_directly=True, ignore_data=None):
-        VerifiedElement.__init__(self, data, called_directly=called_directly)
+    def __init__(self, data: Dict[str, Any], raise_on_unknown: bool = True, called_directly: bool = True, ignore_data: Optional[List[str]] = None):
+        VerifiedElement.__init__(self, data, raise_on_unknown=raise_on_unknown, called_directly=called_directly, ignore_data=ignore_data)
 
         self.is_primary = data.pop('primary', False)
 

--- a/src/eduid_userdb/element.py
+++ b/src/eduid_userdb/element.py
@@ -98,6 +98,7 @@ class Element(object):
 
     def __init__(self, data: Dict[str, Any], called_directly: bool = True):
         if called_directly:
+            breakpoint()
             warnings.warn("Element.__init__ called directly", DeprecationWarning)
 
         if not isinstance(data, dict):

--- a/src/eduid_userdb/element.py
+++ b/src/eduid_userdb/element.py
@@ -116,7 +116,7 @@ class Element(object):
     @classmethod
     def from_dict(cls: Type[TElementSubclass], data: Dict[str, Any]) -> TElementSubclass:
         """
-        Construct user from a data dict.
+        Construct element from a data dict.
         """
         return cls(data=data, called_directly=False)
 
@@ -312,7 +312,7 @@ class PrimaryElement(VerifiedElement):
         cls: Type[TPrimaryElementSubclass], data: Dict[str, Any], raise_on_unknown: bool = True
     ) -> TPrimaryElementSubclass:
         """
-        Construct user from a data dict.
+        Construct primary element from a data dict.
         """
         return cls(data=data, called_directly=False, raise_on_unknown=raise_on_unknown)
 

--- a/src/eduid_userdb/element.py
+++ b/src/eduid_userdb/element.py
@@ -208,7 +208,7 @@ class VerifiedElement(Element):
     def __init__(
         self, data: Dict[str, Any], called_directly: bool = True,
     ):
-        Element.__init__(self, data, called_directly=called_directly)
+        super().__init__(data, called_directly=called_directly)
         # Remove deprecated verification_code from VerifiedElement
         data.pop('verification_code', None)
         self.is_verified = data.pop('verified', False)

--- a/src/eduid_userdb/element.py
+++ b/src/eduid_userdb/element.py
@@ -103,7 +103,7 @@ class Element(object):
 
         if not isinstance(data, dict):
             raise UserDBValueError("Invalid 'data', not dict ({!r})".format(type(data)))
-        self._data = {}
+        self._data: Dict[str, Any] = {}
 
         self.created_by = data.pop('created_by', None)
         self.created_ts = data.pop('created_ts', None)

--- a/src/eduid_userdb/element.py
+++ b/src/eduid_userdb/element.py
@@ -96,7 +96,13 @@ class Element(object):
         created_ts
     """
 
-    def __init__(self, data: Dict[str, Any], raise_on_unknown: bool = True, called_directly: bool = True, ignore_data: Optional[List[str]] = None):
+    def __init__(
+        self,
+        data: Dict[str, Any],
+        raise_on_unknown: bool = True,
+        called_directly: bool = True,
+        ignore_data: Optional[List[str]] = None,
+    ):
         if called_directly:
             breakpoint()
             warnings.warn("Element.__init__ called directly", DeprecationWarning)
@@ -204,8 +210,16 @@ class VerifiedElement(Element):
         verified_ts
     """
 
-    def __init__(self, data: Dict[str, Any], raise_on_unknown: bool = True, called_directly: bool = True, ignore_data: Optional[List[str]] = None):
-        Element.__init__(self, data, raise_on_unknown=raise_on_unknown, called_directly=called_directly, ignore_data=ignore_data)
+    def __init__(
+        self,
+        data: Dict[str, Any],
+        raise_on_unknown: bool = True,
+        called_directly: bool = True,
+        ignore_data: Optional[List[str]] = None,
+    ):
+        Element.__init__(
+            self, data, raise_on_unknown=raise_on_unknown, called_directly=called_directly, ignore_data=ignore_data
+        )
         # Remove deprecated verification_code from VerifiedElement
         data.pop('verification_code', None)
         self.is_verified = data.pop('verified', False)
@@ -282,8 +296,16 @@ class PrimaryElement(VerifiedElement):
     :type raise_on_unknown: bool
     """
 
-    def __init__(self, data: Dict[str, Any], raise_on_unknown: bool = True, called_directly: bool = True, ignore_data: Optional[List[str]] = None):
-        VerifiedElement.__init__(self, data, raise_on_unknown=raise_on_unknown, called_directly=called_directly, ignore_data=ignore_data)
+    def __init__(
+        self,
+        data: Dict[str, Any],
+        raise_on_unknown: bool = True,
+        called_directly: bool = True,
+        ignore_data: Optional[List[str]] = None,
+    ):
+        VerifiedElement.__init__(
+            self, data, raise_on_unknown=raise_on_unknown, called_directly=called_directly, ignore_data=ignore_data
+        )
 
         self.is_primary = data.pop('primary', False)
 

--- a/src/eduid_userdb/element.py
+++ b/src/eduid_userdb/element.py
@@ -97,9 +97,7 @@ class Element(object):
     """
 
     def __init__(
-        self,
-        data: Dict[str, Any],
-        called_directly: bool = True,
+        self, data: Dict[str, Any], called_directly: bool = True,
     ):
         if called_directly:
             breakpoint()
@@ -209,13 +207,9 @@ class VerifiedElement(Element):
     """
 
     def __init__(
-        self,
-        data: Dict[str, Any],
-        called_directly: bool = True,
+        self, data: Dict[str, Any], called_directly: bool = True,
     ):
-        Element.__init__(
-            self, data, called_directly=called_directly
-        )
+        Element.__init__(self, data, called_directly=called_directly)
         # Remove deprecated verification_code from VerifiedElement
         data.pop('verification_code', None)
         self.is_verified = data.pop('verified', False)
@@ -302,9 +296,7 @@ class PrimaryElement(VerifiedElement):
         called_directly: bool = True,
         ignore_data: Optional[List[str]] = None,
     ):
-        VerifiedElement.__init__(
-            self, data, called_directly=called_directly
-        )
+        VerifiedElement.__init__(self, data, called_directly=called_directly)
 
         self.is_primary = data.pop('primary', False)
 
@@ -317,7 +309,9 @@ class PrimaryElement(VerifiedElement):
             self._data.update(data)
 
     @classmethod
-    def from_dict(cls: Type[TPrimaryElementSubclass], data: Dict[str, Any], raise_on_unknown: bool = True) -> TPrimaryElementSubclass:
+    def from_dict(
+        cls: Type[TPrimaryElementSubclass], data: Dict[str, Any], raise_on_unknown: bool = True
+    ) -> TPrimaryElementSubclass:
         """
         Construct user from a data dict.
         """

--- a/src/eduid_userdb/element.py
+++ b/src/eduid_userdb/element.py
@@ -100,7 +100,6 @@ class Element(object):
         self, data: Dict[str, Any], called_directly: bool = True,
     ):
         if called_directly:
-            breakpoint()
             warnings.warn("Element.__init__ called directly", DeprecationWarning)
 
         if not isinstance(data, dict):

--- a/src/eduid_userdb/event.py
+++ b/src/eduid_userdb/event.py
@@ -34,7 +34,7 @@
 #
 
 import copy
-from typing import Any, Dict, List, Type
+from typing import Any, Dict, List, Type, TypeVar
 
 from bson import ObjectId
 
@@ -47,6 +47,9 @@ from eduid_userdb.exceptions import BadEvent, EventHasUnknownData, UserDBValueEr
 #   src/eduid_userdb/event.py:45: error: Argument 2 to NewType(...) must be subclassable (got "Any")
 class EventId(ObjectId):
     pass
+
+
+TEventSubclass = TypeVar('TEventSubclass', bound='Event')
 
 
 class Event(Element):
@@ -100,6 +103,13 @@ class Event(Element):
                 raise EventHasUnknownData('Event {!r} unknown data: {!r}'.format(self.event_id, leftovers,))
             # Just keep everything that is left as-is
             self._data.update(data)
+
+    @classmethod
+    def from_dict(cls: Type[TEventSubclass], data: Dict[str, Any], raise_on_unknown: bool = True) -> TEventSubclass:
+        """
+        Construct user from a data dict.
+        """
+        return cls(data=data, called_directly=False, raise_on_unknown=raise_on_unknown)
 
     # -----------------------------------------------------------------
     @property

--- a/src/eduid_userdb/event.py
+++ b/src/eduid_userdb/event.py
@@ -32,6 +32,7 @@
 #
 # Author : Fredrik Thulin <fredrik@thulin.net>
 #
+from __future__ import annotations
 
 import copy
 from datetime import datetime
@@ -88,7 +89,7 @@ class Event(Element):
         if 'modified_ts' not in data:
             data['modified_ts'] = data.get('created_ts', None)
 
-        Element.__init__(self, data, called_directly=called_directly)
+        super().__init__(data, called_directly=called_directly)
         self.event_type = data.pop('event_type', None)
         if 'id' in data:  # Compatibility for old format
             data['event_id'] = data.pop('id')
@@ -103,7 +104,7 @@ class Event(Element):
             self._data.update(data)
 
     @classmethod
-    def from_dict(cls: Type['Event'], data: Dict[str, Any], raise_on_unknown: bool = True) -> 'Event':
+    def from_dict(cls: Type[Event], data: Dict[str, Any], raise_on_unknown: bool = True) -> Event:
         """
         Construct event from a data dict.
         """

--- a/src/eduid_userdb/event.py
+++ b/src/eduid_userdb/event.py
@@ -65,6 +65,7 @@ class Event(Element):
         event_type=None,
         event_id=None,
         raise_on_unknown=True,
+        called_directly=True,
         ignore_data=None,
     ):
         data_in = data
@@ -86,7 +87,7 @@ class Event(Element):
         if 'modified_ts' not in data:
             data['modified_ts'] = data.get('created_ts', None)
 
-        Element.__init__(self, data)
+        Element.__init__(self, data, called_directly=called_directly)
         self.event_type = data.pop('event_type', None)
         if 'id' in data:  # Compatibility for old format
             data['event_id'] = data.pop('id')

--- a/src/eduid_userdb/event.py
+++ b/src/eduid_userdb/event.py
@@ -176,7 +176,7 @@ class EventList(ElementList):
                 if 'event_type' in this:
                     event = event_from_dict(this, raise_on_unknown=raise_on_unknown)
                 else:
-                    event = self._event_class(data=this)
+                    event = self._event_class.from_dict(this)
                 self.add(event)
 
     def add(self, event) -> None:
@@ -212,5 +212,5 @@ def event_from_dict(data: Dict[str, Any], raise_on_unknown: bool = True):
     if data['event_type'] == 'tou_event':
         from eduid_userdb.tou import ToUEvent  # avoid cyclic dependency by importing this here
 
-        return ToUEvent(data=data, raise_on_unknown=raise_on_unknown)
+        return ToUEvent.from_dict(data=data, raise_on_unknown=raise_on_unknown)
     raise BadEvent('Unknown event_type in data: {!s}'.format(data['event_type']))

--- a/src/eduid_userdb/event.py
+++ b/src/eduid_userdb/event.py
@@ -34,7 +34,7 @@
 #
 
 import copy
-from typing import Any, Dict, List, Type, TypeVar
+from typing import Any, Dict, List, Type
 
 from bson import ObjectId
 
@@ -47,9 +47,6 @@ from eduid_userdb.exceptions import BadEvent, EventHasUnknownData, UserDBValueEr
 #   src/eduid_userdb/event.py:45: error: Argument 2 to NewType(...) must be subclassable (got "Any")
 class EventId(ObjectId):
     pass
-
-
-TEventSubclass = TypeVar('TEventSubclass', bound='Event')
 
 
 class Event(Element):
@@ -105,9 +102,9 @@ class Event(Element):
             self._data.update(data)
 
     @classmethod
-    def from_dict(cls: Type[TEventSubclass], data: Dict[str, Any], raise_on_unknown: bool = True) -> TEventSubclass:
+    def from_dict(cls: Type['Event'], data: Dict[str, Any], raise_on_unknown: bool = True) -> 'Event':
         """
-        Construct user from a data dict.
+        Construct event from a data dict.
         """
         return cls(data=data, called_directly=False, raise_on_unknown=raise_on_unknown)
 

--- a/src/eduid_userdb/event.py
+++ b/src/eduid_userdb/event.py
@@ -34,7 +34,8 @@
 #
 
 import copy
-from typing import Any, Dict, List, Type
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Type, Union
 
 from bson import ObjectId
 
@@ -58,15 +59,15 @@ class Event(Element):
 
     def __init__(
         self,
-        application=None,
-        created_ts=None,
-        modified_ts=None,
-        data=None,
-        event_type=None,
-        event_id=None,
-        raise_on_unknown=True,
-        called_directly=True,
-        ignore_data=None,
+        application: Optional[str] = None,
+        created_ts: Optional[Union[datetime, bool]] = None,
+        modified_ts: Optional[Union[datetime, bool]] = None,
+        data: Optional[Dict[str, Any]] = None,
+        event_type: Optional[str] = None,
+        event_id: Optional[str] = None,
+        raise_on_unknown: bool = True,
+        called_directly: bool = True,
+        ignore_data: Optional[List[str]] = None,
     ):
         data_in = data
         data = copy.copy(data_in)  # to not modify callers data

--- a/src/eduid_userdb/fixtures/email_addresses.py
+++ b/src/eduid_userdb/fixtures/email_addresses.py
@@ -34,8 +34,8 @@ from datetime import datetime
 
 from eduid_userdb.mail import MailAddress
 
-johnsmith_example_com = MailAddress(
-    data={
+johnsmith_example_com = MailAddress.from_dict(
+    {
         'email': 'johnsmith@example.com',
         'created_by': 'signup',
         'created_ts': datetime.fromisoformat("2013-09-02T10:23:25"),
@@ -47,8 +47,8 @@ johnsmith_example_com = MailAddress(
 )
 
 
-johnsmith2_example_com = MailAddress(
-    data={
+johnsmith2_example_com = MailAddress.from_dict(
+    {
         'email': 'johnsmith2@example.com',
         'created_by': 'dashboard',
         'created_ts': datetime.fromisoformat("2013-09-02T10:23:25"),
@@ -60,8 +60,8 @@ johnsmith2_example_com = MailAddress(
 )
 
 
-johnsmith3_example_com = MailAddress(
-    data={
+johnsmith3_example_com = MailAddress.from_dict(
+    {
         'email': 'johnsmith3@example.com',
         'created_by': 'signup',
         'created_ts': datetime.fromisoformat("2017-01-04T15:47:27"),
@@ -73,17 +73,17 @@ johnsmith3_example_com = MailAddress(
 )
 
 
-johnsmith_example_com_old = MailAddress(data={'email': 'johnsmith@example.com', 'verified': True, 'primary': True})
+johnsmith_example_com_old = MailAddress.from_dict({'email': 'johnsmith@example.com', 'verified': True, 'primary': True})
 
 
-johnsmith2_example_com_old = MailAddress(data={'email': 'johnsmith2@example.com', 'verified': True})
+johnsmith2_example_com_old = MailAddress.from_dict({'email': 'johnsmith2@example.com', 'verified': True})
 
 
-johnsmith3_example_com_unverified = MailAddress(data={'email': 'johnsmith3@example.com', 'verified': False})
+johnsmith3_example_com_unverified = MailAddress.from_dict({'email': 'johnsmith3@example.com', 'verified': False})
 
 
-johnsmith_example_org = MailAddress(
-    data={
+johnsmith_example_org = MailAddress.from_dict(
+    {
         'email': 'johnsmith@example.org',
         'created_by': 'signup',
         'created_ts': datetime.fromisoformat("2013-09-02T10:23:25"),
@@ -95,8 +95,8 @@ johnsmith_example_org = MailAddress(
 )
 
 
-johnsmith2_example_org = MailAddress(
-    data={
+johnsmith2_example_org = MailAddress.from_dict(
+    {
         'email': 'johnsmith2@example.org',
         'created_by': 'dashboard',
         'created_ts': datetime.fromisoformat("2013-09-02T10:23:25"),

--- a/src/eduid_userdb/fixtures/fido_credentials.py
+++ b/src/eduid_userdb/fixtures/fido_credentials.py
@@ -32,19 +32,19 @@
 #
 from eduid_userdb.credentials import U2F, Webauthn
 
-webauthn_credential = Webauthn(
+webauthn_credential = Webauthn.from_dict(dict(
     keyhandle='i3KjBT0t5TPm693T9O0f4zyiwvdu9cY8BegCjiVvq_FS-ZmPcvXipFvHvD5CH6ZVRR3nsVsOla0Cad3fbtUA_Q',
     credential_data='AAAAAAAAAAAAAAAAAAAAAABAi3KjBT0t5TPm693T9O0f4zyiwvdu9cY8BegCjiVvq_FS-ZmPcvXipFvHvD5CH6ZVRR3nsVsOla0Cad3fbtUA_aUBAgMmIAEhWCCiwDYGxl1LnRMqooWm0aRR9YbBG2LZ84BMNh_4rHkA9yJYIIujMrUOpGekbXjgMQ8M13ZsBD_cROSPB79eGz2Nw1ZE',
     app_id='',
     attest_obj='bzJObWJYUmtibTl1WldkaGRIUlRkRzEwb0doaGRYUm9SR0YwWVZqRXhvVGI1OVBlcEV0YW9PYWY5RDlOUjIxVWJfSU5PT0tfVDdubDFuZHNIUlJCQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQVFJdHlvd1U5TGVVejV1dmQwX1R0SC1NOG9zTDNidlhHUEFYb0FvNGxiNnZ4VXZtWmozTDE0cVJieDd3LVFoLW1WVVVkNTdGYkRwV3RBbW5kMzI3VkFQMmxBUUlESmlBQklWZ2dvc0EyQnNaZFM1MFRLcUtGcHRHa1VmV0d3UnRpMmZPQVREWWYtS3g1QVBjaVdDQ0xveksxRHFSbnBHMTQ0REVQRE5kMmJBUV8zRVRrandlX1hoczlqY05XUkE=',
     description='unit test webauthn token',
-)
+))
 
-u2f_credential = U2F(
+u2f_credential = U2F.from_dict(dict(
     version='U2F_V2',
     keyhandle='V1vXqZcwBJD2RMIH2udd2F7R9NoSNlP7ZSPOtKHzS7n_rHFXcXbSpOoX__aUKyTR6jEC8Xv678WjXC5KEkvziA',
     public_key='BHVTWuo3_D7ruRBe2Tw-m2atT2IOm_qQWSDreWShu3t21ne9c-DPSUdym-H-t7FcjV7rj1dSc3WSwaOJpFmkKxQ',
     app_id='https://eduid.se/u2f-app-id.json',
     attest_cert='',
     description='unit test U2F token',
-)
+))

--- a/src/eduid_userdb/fixtures/fido_credentials.py
+++ b/src/eduid_userdb/fixtures/fido_credentials.py
@@ -32,19 +32,23 @@
 #
 from eduid_userdb.credentials import U2F, Webauthn
 
-webauthn_credential = Webauthn.from_dict(dict(
-    keyhandle='i3KjBT0t5TPm693T9O0f4zyiwvdu9cY8BegCjiVvq_FS-ZmPcvXipFvHvD5CH6ZVRR3nsVsOla0Cad3fbtUA_Q',
-    credential_data='AAAAAAAAAAAAAAAAAAAAAABAi3KjBT0t5TPm693T9O0f4zyiwvdu9cY8BegCjiVvq_FS-ZmPcvXipFvHvD5CH6ZVRR3nsVsOla0Cad3fbtUA_aUBAgMmIAEhWCCiwDYGxl1LnRMqooWm0aRR9YbBG2LZ84BMNh_4rHkA9yJYIIujMrUOpGekbXjgMQ8M13ZsBD_cROSPB79eGz2Nw1ZE',
-    app_id='',
-    attest_obj='bzJObWJYUmtibTl1WldkaGRIUlRkRzEwb0doaGRYUm9SR0YwWVZqRXhvVGI1OVBlcEV0YW9PYWY5RDlOUjIxVWJfSU5PT0tfVDdubDFuZHNIUlJCQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQVFJdHlvd1U5TGVVejV1dmQwX1R0SC1NOG9zTDNidlhHUEFYb0FvNGxiNnZ4VXZtWmozTDE0cVJieDd3LVFoLW1WVVVkNTdGYkRwV3RBbW5kMzI3VkFQMmxBUUlESmlBQklWZ2dvc0EyQnNaZFM1MFRLcUtGcHRHa1VmV0d3UnRpMmZPQVREWWYtS3g1QVBjaVdDQ0xveksxRHFSbnBHMTQ0REVQRE5kMmJBUV8zRVRrandlX1hoczlqY05XUkE=',
-    description='unit test webauthn token',
-))
+webauthn_credential = Webauthn.from_dict(
+    dict(
+        keyhandle='i3KjBT0t5TPm693T9O0f4zyiwvdu9cY8BegCjiVvq_FS-ZmPcvXipFvHvD5CH6ZVRR3nsVsOla0Cad3fbtUA_Q',
+        credential_data='AAAAAAAAAAAAAAAAAAAAAABAi3KjBT0t5TPm693T9O0f4zyiwvdu9cY8BegCjiVvq_FS-ZmPcvXipFvHvD5CH6ZVRR3nsVsOla0Cad3fbtUA_aUBAgMmIAEhWCCiwDYGxl1LnRMqooWm0aRR9YbBG2LZ84BMNh_4rHkA9yJYIIujMrUOpGekbXjgMQ8M13ZsBD_cROSPB79eGz2Nw1ZE',
+        app_id='',
+        attest_obj='bzJObWJYUmtibTl1WldkaGRIUlRkRzEwb0doaGRYUm9SR0YwWVZqRXhvVGI1OVBlcEV0YW9PYWY5RDlOUjIxVWJfSU5PT0tfVDdubDFuZHNIUlJCQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQVFJdHlvd1U5TGVVejV1dmQwX1R0SC1NOG9zTDNidlhHUEFYb0FvNGxiNnZ4VXZtWmozTDE0cVJieDd3LVFoLW1WVVVkNTdGYkRwV3RBbW5kMzI3VkFQMmxBUUlESmlBQklWZ2dvc0EyQnNaZFM1MFRLcUtGcHRHa1VmV0d3UnRpMmZPQVREWWYtS3g1QVBjaVdDQ0xveksxRHFSbnBHMTQ0REVQRE5kMmJBUV8zRVRrandlX1hoczlqY05XUkE=',
+        description='unit test webauthn token',
+    )
+)
 
-u2f_credential = U2F.from_dict(dict(
-    version='U2F_V2',
-    keyhandle='V1vXqZcwBJD2RMIH2udd2F7R9NoSNlP7ZSPOtKHzS7n_rHFXcXbSpOoX__aUKyTR6jEC8Xv678WjXC5KEkvziA',
-    public_key='BHVTWuo3_D7ruRBe2Tw-m2atT2IOm_qQWSDreWShu3t21ne9c-DPSUdym-H-t7FcjV7rj1dSc3WSwaOJpFmkKxQ',
-    app_id='https://eduid.se/u2f-app-id.json',
-    attest_cert='',
-    description='unit test U2F token',
-))
+u2f_credential = U2F.from_dict(
+    dict(
+        version='U2F_V2',
+        keyhandle='V1vXqZcwBJD2RMIH2udd2F7R9NoSNlP7ZSPOtKHzS7n_rHFXcXbSpOoX__aUKyTR6jEC8Xv678WjXC5KEkvziA',
+        public_key='BHVTWuo3_D7ruRBe2Tw-m2atT2IOm_qQWSDreWShu3t21ne9c-DPSUdym-H-t7FcjV7rj1dSc3WSwaOJpFmkKxQ',
+        app_id='https://eduid.se/u2f-app-id.json',
+        attest_cert='',
+        description='unit test U2F token',
+    )
+)

--- a/src/eduid_userdb/fixtures/locked_identities.py
+++ b/src/eduid_userdb/fixtures/locked_identities.py
@@ -34,6 +34,6 @@ from datetime import datetime
 
 from eduid_userdb.locked_identity import LockedIdentityNin
 
-dashboard_locked_nin = LockedIdentityNin(
-    number='197801011234', created_by='dashboard', created_ts=datetime.fromisoformat("2013-09-02T10:23:25"),
+dashboard_locked_nin = LockedIdentityNin.from_dict(
+    dict(number='197801011234', created_by='dashboard', created_ts=datetime.fromisoformat("2013-09-02T10:23:25"))
 )

--- a/src/eduid_userdb/fixtures/nins.py
+++ b/src/eduid_userdb/fixtures/nins.py
@@ -34,8 +34,8 @@ from datetime import datetime
 
 from eduid_userdb.nin import Nin
 
-dashboard_primary_nin = Nin(
-    data={
+dashboard_primary_nin = Nin.from_dict(
+    {
         'number': '197801011234',
         'created_ts': datetime.fromisoformat("2013-09-02T10:23:25"),
         'created_by': 'dashboard',
@@ -47,8 +47,8 @@ dashboard_primary_nin = Nin(
 )
 
 
-dashboard_verified_nin = Nin(
-    data={
+dashboard_verified_nin = Nin.from_dict(
+    {
         'number': '197801011235',
         'created_ts': datetime.fromisoformat("2013-09-02T10:23:25"),
         'created_by': 'dashboard',

--- a/src/eduid_userdb/fixtures/passwords.py
+++ b/src/eduid_userdb/fixtures/passwords.py
@@ -36,8 +36,8 @@ from bson import ObjectId
 
 from eduid_userdb.credentials import Password
 
-signup_password = Password(
-    data={
+signup_password = Password.from_dict(
+    {
         'id': ObjectId('112345678901234567890123'),
         'salt': '$NDNv1H1$9c810d852430b62a9a7c6159d5d64c41c3831846f81b6799b54e1e8922f11545$32$32$',
         'created_by': 'signup',
@@ -46,8 +46,8 @@ signup_password = Password(
 )
 
 
-signup_password_2 = Password(
-    data={
+signup_password_2 = Password.from_dict(
+    {
         'id': ObjectId('a12345678901234567890123'),
         'salt': '$NDNv1H1$2d465dcc9c68075aa095b646a98e2e3edb1c612c175ebdeaca6c9a55a0457833$32$32$',
         'created_by': 'signup',
@@ -56,8 +56,8 @@ signup_password_2 = Password(
 )
 
 
-old_password = Password(
-    data={
+old_password = Password.from_dict(
+    {
         'id': ObjectId('112345678901234567890123'),
         'salt': '$NDNv1H1$9c810d852430b62a9a7c6159d5d64c41c3831846f81b6799b54e1e8922f11545$32$32$',
         'source': 'signup',

--- a/src/eduid_userdb/fixtures/pending_emails.py
+++ b/src/eduid_userdb/fixtures/pending_emails.py
@@ -34,8 +34,8 @@ from datetime import datetime
 
 from eduid_userdb.proofing import EmailProofingElement
 
-johnsmith2_example_com_pending = EmailProofingElement(
-    data={
+johnsmith2_example_com_pending = EmailProofingElement.from_dict(
+    {
         'email': 'johnsmith2@example.com',
         'created_by': 'dashboard',
         'created_ts': datetime.fromisoformat("2013-09-02T10:23:25"),

--- a/src/eduid_userdb/fixtures/phones.py
+++ b/src/eduid_userdb/fixtures/phones.py
@@ -34,8 +34,8 @@ from datetime import datetime
 
 from eduid_userdb.phone import PhoneNumber
 
-dashboard_primary_phone = PhoneNumber(
-    data={
+dashboard_primary_phone = PhoneNumber.from_dict(
+    {
         'number': '+34609609609',
         'created_ts': datetime.fromisoformat("2013-09-02T10:23:25"),
         'created_by': 'dashboard',
@@ -47,8 +47,8 @@ dashboard_primary_phone = PhoneNumber(
 )
 
 
-dashboard_verified_phone = PhoneNumber(
-    data={
+dashboard_verified_phone = PhoneNumber.from_dict(
+    {
         'number': '+34607507507',
         'verified': True,
         'created_ts': datetime.fromisoformat("2013-09-02T10:23:25"),
@@ -59,8 +59,8 @@ dashboard_verified_phone = PhoneNumber(
 )
 
 
-dashboard_unverified_phone = PhoneNumber(
-    data={
+dashboard_unverified_phone = PhoneNumber.from_dict(
+    {
         'number': '+34 6096096096',
         'created_ts': datetime.fromisoformat("2013-09-02T10:23:25"),
         'created_by': 'dashboard',
@@ -71,7 +71,7 @@ dashboard_unverified_phone = PhoneNumber(
 )
 
 
-old_primary_phone = PhoneNumber(data={'mobile': '+34609609609', 'primary': True, 'verified': True})
+old_primary_phone = PhoneNumber.from_dict({'mobile': '+34609609609', 'primary': True, 'verified': True})
 
 
-old_unverified_phone = PhoneNumber(data={'mobile': '+34 6096096096', 'verified': False})
+old_unverified_phone = PhoneNumber.from_dict({'mobile': '+34 6096096096', 'verified': False})

--- a/src/eduid_userdb/fixtures/tous.py
+++ b/src/eduid_userdb/fixtures/tous.py
@@ -36,8 +36,8 @@ from bson import ObjectId
 
 from eduid_userdb.tou import ToUEvent
 
-signup_2016_v1 = ToUEvent(
-    data={
+signup_2016_v1 = ToUEvent.from_dict(
+    {
         'event_id': ObjectId('912345678901234567890123'),
         'version': '2016-v1',
         'created_ts': datetime.fromisoformat("2017-01-04T16:47:30"),

--- a/src/eduid_userdb/locked_identity.py
+++ b/src/eduid_userdb/locked_identity.py
@@ -79,7 +79,7 @@ class LockedIdentityNin(LockedIdentityElement):
 
         data['identity_type'] = 'nin'
 
-        LockedIdentityElement.__init__(self, data, called_directly=called_directly)
+        super().__init__(data, called_directly=called_directly)
         self.number = number
 
     # -----------------------------------------------------------------

--- a/src/eduid_userdb/locked_identity.py
+++ b/src/eduid_userdb/locked_identity.py
@@ -21,8 +21,8 @@ class LockedIdentityElement(Element):
         identity_type
     """
 
-    def __init__(self, data, raise_on_unknown=True, called_directly=True):
-        Element.__init__(self, data, raise_on_unknown=raise_on_unknown, called_directly=called_directly)
+    def __init__(self, data, called_directly=True):
+        Element.__init__(self, data, called_directly=called_directly)
         self.identity_type = data.pop('identity_type')
 
     # -----------------------------------------------------------------
@@ -70,7 +70,6 @@ class LockedIdentityNin(LockedIdentityElement):
         created_by: Optional[str] = None,
         created_ts: Optional[datetime] = None,
         data: Optional[Dict[str, Any]] = None,
-        raise_on_unknown: bool = True,
         called_directly: bool = True,
     ):
         if data is None:
@@ -80,7 +79,7 @@ class LockedIdentityNin(LockedIdentityElement):
 
         data['identity_type'] = 'nin'
 
-        LockedIdentityElement.__init__(self, data, raise_on_unknown=raise_on_unknown, called_directly=called_directly)
+        LockedIdentityElement.__init__(self, data, called_directly=called_directly)
         self.number = number
 
     # -----------------------------------------------------------------

--- a/src/eduid_userdb/locked_identity.py
+++ b/src/eduid_userdb/locked_identity.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
+from datetime import datetime
 from six import string_types
+from typing import Any, Dict, Optional
 
 from eduid_userdb.element import Element, ElementList
 from eduid_userdb.exceptions import EduIDUserDBError, UserDBValueError
@@ -18,8 +20,8 @@ class LockedIdentityElement(Element):
         identity_type
     """
 
-    def __init__(self, data):
-        Element.__init__(self, data)
+    def __init__(self, data, called_directly=True):
+        Element.__init__(self, data, called_directly=called_directly)
         self.identity_type = data.pop('identity_type')
 
     # -----------------------------------------------------------------
@@ -61,9 +63,15 @@ class LockedIdentityNin(LockedIdentityElement):
         number
     """
 
-    def __init__(self, number, created_by, created_ts):
-        data = {'created_by': created_by, 'created_ts': created_ts, 'identity_type': 'nin'}
-        LockedIdentityElement.__init__(self, data)
+    def __init__(self, number: Optional[str] = None, created_by: Optional[str] = None, created_ts: Optional[datetime] = None, data: Optional[Dict[str, Any]] = None, called_directly: bool = True):
+        if data is None:
+            data = {'created_by': created_by, 'created_ts': created_ts}
+        else:
+            number = data.pop('number')
+
+        data['identity_type'] = 'nin'
+
+        LockedIdentityElement.__init__(self, data, called_directly=called_directly)
         self.number = number
 
     # -----------------------------------------------------------------

--- a/src/eduid_userdb/locked_identity.py
+++ b/src/eduid_userdb/locked_identity.py
@@ -22,7 +22,7 @@ class LockedIdentityElement(Element):
     """
 
     def __init__(self, data, called_directly=True):
-        Element.__init__(self, data, called_directly=called_directly)
+        super().__init__(data, called_directly=called_directly)
         self.identity_type = data.pop('identity_type')
 
     # -----------------------------------------------------------------

--- a/src/eduid_userdb/locked_identity.py
+++ b/src/eduid_userdb/locked_identity.py
@@ -21,8 +21,8 @@ class LockedIdentityElement(Element):
         identity_type
     """
 
-    def __init__(self, data, called_directly=True):
-        Element.__init__(self, data, called_directly=called_directly)
+    def __init__(self, data, raise_on_unknown=True, called_directly=True):
+        Element.__init__(self, data, raise_on_unknown=raise_on_unknown, called_directly=called_directly)
         self.identity_type = data.pop('identity_type')
 
     # -----------------------------------------------------------------
@@ -70,6 +70,7 @@ class LockedIdentityNin(LockedIdentityElement):
         created_by: Optional[str] = None,
         created_ts: Optional[datetime] = None,
         data: Optional[Dict[str, Any]] = None,
+        raise_on_unknown: bool = True,
         called_directly: bool = True,
     ):
         if data is None:
@@ -79,7 +80,7 @@ class LockedIdentityNin(LockedIdentityElement):
 
         data['identity_type'] = 'nin'
 
-        LockedIdentityElement.__init__(self, data, called_directly=called_directly)
+        LockedIdentityElement.__init__(self, data, raise_on_unknown=raise_on_unknown, called_directly=called_directly)
         self.number = number
 
     # -----------------------------------------------------------------

--- a/src/eduid_userdb/locked_identity.py
+++ b/src/eduid_userdb/locked_identity.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from datetime import datetime
-from six import string_types
 from typing import Any, Dict, Optional
+
+from six import string_types
 
 from eduid_userdb.element import Element, ElementList
 from eduid_userdb.exceptions import EduIDUserDBError, UserDBValueError
@@ -63,7 +64,14 @@ class LockedIdentityNin(LockedIdentityElement):
         number
     """
 
-    def __init__(self, number: Optional[str] = None, created_by: Optional[str] = None, created_ts: Optional[datetime] = None, data: Optional[Dict[str, Any]] = None, called_directly: bool = True):
+    def __init__(
+        self,
+        number: Optional[str] = None,
+        created_by: Optional[str] = None,
+        created_ts: Optional[datetime] = None,
+        data: Optional[Dict[str, Any]] = None,
+        called_directly: bool = True,
+    ):
         if data is None:
             data = {'created_by': created_by, 'created_ts': created_ts}
         else:

--- a/src/eduid_userdb/locked_identity.py
+++ b/src/eduid_userdb/locked_identity.py
@@ -112,8 +112,8 @@ class LockedIdentityList(ElementList):
             else:
                 if item['identity_type'] == 'nin':
                     elements.append(
-                        LockedIdentityNin(
-                            number=item['number'], created_by=item['created_by'], created_ts=item['created_ts']
+                        LockedIdentityNin.from_dict(
+                            dict(number=item['number'], created_by=item['created_by'], created_ts=item['created_ts'])
                         )
                     )
         ElementList.__init__(self, elements)

--- a/src/eduid_userdb/logs/element.py
+++ b/src/eduid_userdb/logs/element.py
@@ -5,7 +5,6 @@
 
 from __future__ import absolute_import
 
-from typing import Any, Dict, Optional
 import logging
 
 import six
@@ -18,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 class LogElement(Element):
-    def __init__(self, created_by: Optional[str] = None, data: Optional[Dict[str, Any]] = None, called_directly: bool = True):
+    def __init__(self, created_by):
         """
         :param created_by: Application creating the log element
 
@@ -28,12 +27,9 @@ class LogElement(Element):
         :rtype: LogElement
         """
         self._required_keys = ['created_by', 'created_ts']
-        if data is None:
-            data = {'created_by': created_by, 'created_ts': True}
-        else:
-            data['created_ts'] = True
-
-        super(LogElement, self).__init__(data=data, called_directly=called_directly)
+        # Since log elements are already nearer dataclasses than the rest of elements,
+        # we do not deprecate direct calls to their __init__, which is close to what a dataclass would provide.
+        super(LogElement, self).__init__(data={'created_by': created_by, 'created_ts': True}, called_directly=False)
 
     def validate(self):
         # Check that all keys are accounted for and that no string values are blank
@@ -54,7 +50,7 @@ class LogElement(Element):
 
 
 class ProofingLogElement(LogElement):
-    def __init__(self, user, created_by, proofing_method, proofing_version, called_directly=True):
+    def __init__(self, user, created_by, proofing_method, proofing_version):
         """
         :param user: User object
         :param created_by: Application creating the log element
@@ -69,7 +65,7 @@ class ProofingLogElement(LogElement):
         :return: ProofingLogElement object
         :rtype: ProofingLogElement
         """
-        super(ProofingLogElement, self).__init__(created_by=created_by, called_directly=called_directly)
+        super(ProofingLogElement, self).__init__(created_by)
         self._required_keys.extend(['eduPersonPrincipalName', 'proofing_method', 'proofing_version'])
         self._data['eduPersonPrincipalName'] = user.eppn
         self._data['proofing_method'] = proofing_method
@@ -77,7 +73,7 @@ class ProofingLogElement(LogElement):
 
 
 class NinProofingLogElement(ProofingLogElement):
-    def __init__(self, user, created_by, nin, user_postal_address, proofing_method, proofing_version, called_directly=True):
+    def __init__(self, user, created_by, nin, user_postal_address, proofing_method, proofing_version):
         """
         :param user: user object
         :param created_by: Application creating the log element
@@ -95,7 +91,7 @@ class NinProofingLogElement(ProofingLogElement):
         :rtype: NinProofingLogElement
         """
         super(NinProofingLogElement, self).__init__(
-            user, created_by, proofing_method=proofing_method, proofing_version=proofing_version, called_directly=called_directly
+            user, created_by, proofing_method=proofing_method, proofing_version=proofing_version
         )
         self._required_keys.extend(['nin', 'user_postal_address'])
         self._data['nin'] = nin
@@ -119,7 +115,7 @@ class MailAddressProofing(ProofingLogElement):
     }
     """
 
-    def __init__(self, user, created_by, mail_address, reference, proofing_version, called_directly=True):
+    def __init__(self, user, created_by, mail_address, reference, proofing_version):
         """
         :param user: User object
         :param created_by: Application creating the log element
@@ -137,7 +133,7 @@ class MailAddressProofing(ProofingLogElement):
         :rtype: MailAddressProofing
         """
         super(MailAddressProofing, self).__init__(
-            user, created_by, proofing_method='e-mail', proofing_version=proofing_version, called_directly=called_directly
+            user, created_by, proofing_method='e-mail', proofing_version=proofing_version
         )
         self._required_keys.extend(['mail_address', 'reference'])
         self._data['mail_address'] = mail_address
@@ -157,7 +153,7 @@ class PhoneNumberProofing(ProofingLogElement):
     }
     """
 
-    def __init__(self, user, created_by, phone_number, reference, proofing_version, called_directly=True):
+    def __init__(self, user, created_by, phone_number, reference, proofing_version):
         """
         :param user: User object
         :param created_by: Application creating the log element
@@ -175,7 +171,7 @@ class PhoneNumberProofing(ProofingLogElement):
         :rtype: PhoneNumberProofing
         """
         super(PhoneNumberProofing, self).__init__(
-            user, created_by, proofing_method='sms', proofing_version=proofing_version, called_directly=called_directly
+            user, created_by, proofing_method='sms', proofing_version=proofing_version
         )
         self._required_keys.extend(['phone_number', 'reference'])
         self._data['phone_number'] = phone_number
@@ -198,7 +194,7 @@ class TeleAdressProofing(NinProofingLogElement):
     }
     """
 
-    def __init__(self, user, created_by, reason, nin, mobile_number, user_postal_address, proofing_version, called_directly=True):
+    def __init__(self, user, created_by, reason, nin, mobile_number, user_postal_address, proofing_version):
         """
         :param user: user object
         :param created_by: Application creating the log element
@@ -220,7 +216,7 @@ class TeleAdressProofing(NinProofingLogElement):
         :rtype: TeleAdressProofing
         """
         super(TeleAdressProofing, self).__init__(
-            user, created_by, nin, user_postal_address, proofing_method='TeleAdress', proofing_version=proofing_version, called_directly=called_directly
+            user, created_by, nin, user_postal_address, proofing_method='TeleAdress', proofing_version=proofing_version
         )
         self._required_keys.extend(['reason', 'mobile_number'])
         self._data['reason'] = reason
@@ -258,7 +254,6 @@ class TeleAdressProofingRelation(TeleAdressProofing):
         registered_relation,
         registered_postal_address,
         proofing_version,
-        called_directly=True,
     ):
         """
         :param user: user object
@@ -287,7 +282,7 @@ class TeleAdressProofingRelation(TeleAdressProofing):
         :rtype: TeleAdressProofingRelation
         """
         super(TeleAdressProofingRelation, self).__init__(
-            user, created_by, reason, nin, mobile_number, user_postal_address, proofing_version=proofing_version, called_directly=called_directly
+            user, created_by, reason, nin, mobile_number, user_postal_address, proofing_version=proofing_version
         )
         self._required_keys.extend(['mobile_number_registered_to', 'registered_relation', 'registered_postal_address'])
         self._data['mobile_number_registered_to'] = mobile_number_registered_to
@@ -310,7 +305,7 @@ class LetterProofing(NinProofingLogElement):
     }
     """
 
-    def __init__(self, user, created_by, nin, letter_sent_to, transaction_id, user_postal_address, proofing_version, called_directly=True):
+    def __init__(self, user, created_by, nin, letter_sent_to, transaction_id, user_postal_address, proofing_version):
         """
         :param user: user object
         :param created_by: Application creating the log element
@@ -332,7 +327,7 @@ class LetterProofing(NinProofingLogElement):
         :rtype: LetterProofing
         """
         super(LetterProofing, self).__init__(
-            user, created_by, nin, user_postal_address, proofing_method='letter', proofing_version=proofing_version, called_directly=called_directly
+            user, created_by, nin, user_postal_address, proofing_method='letter', proofing_version=proofing_version
         )
         self._required_keys.extend(['proofing_method', 'letter_sent_to', 'transaction_id'])
         self._data['letter_sent_to'] = letter_sent_to
@@ -354,7 +349,7 @@ class SeLegProofing(NinProofingLogElement):
     }
     """
 
-    def __init__(self, user, created_by, nin, vetting_by, transaction_id, user_postal_address, proofing_version, called_directly=True):
+    def __init__(self, user, created_by, nin, vetting_by, transaction_id, user_postal_address, proofing_version):
         """
         :param user: user object
         :param created_by: Application creating the log element
@@ -376,7 +371,7 @@ class SeLegProofing(NinProofingLogElement):
         :rtype: SeLegProofing
         """
         super(SeLegProofing, self).__init__(
-            user, created_by, nin, user_postal_address, proofing_method='se-leg', proofing_version=proofing_version, called_directly=called_directly
+            user, created_by, nin, user_postal_address, proofing_method='se-leg', proofing_version=proofing_version
         )
         self._required_keys.extend(['proofing_method', 'vetting_by', 'transaction_id'])
         self._data['vetting_by'] = vetting_by
@@ -399,7 +394,7 @@ class SeLegProofingFrejaEid(SeLegProofing):
     }
     """
 
-    def __init__(self, user, created_by, nin, transaction_id, opaque_data, user_postal_address, proofing_version, called_directly=True):
+    def __init__(self, user, created_by, nin, transaction_id, opaque_data, user_postal_address, proofing_version):
         """
         :param user: user object
         :param created_by: Application creating the log element
@@ -428,7 +423,6 @@ class SeLegProofingFrejaEid(SeLegProofing):
             transaction_id=transaction_id,
             user_postal_address=user_postal_address,
             proofing_version=proofing_version,
-            called_directly=called_directly
         )
         self._required_keys.extend(['opaque_data'])
         self._data['opaque_data'] = opaque_data
@@ -448,7 +442,7 @@ class OrcidProofing(ProofingLogElement):
     }
     """
 
-    def __init__(self, user, created_by, orcid, issuer, audience, proofing_method, proofing_version, called_directly=True):
+    def __init__(self, user, created_by, orcid, issuer, audience, proofing_method, proofing_version):
         """
         :param user: User object
         :param created_by: Application creating the log element
@@ -470,7 +464,7 @@ class OrcidProofing(ProofingLogElement):
         :rtype: ProofingLogElement
         """
         super(OrcidProofing, self).__init__(
-            user, created_by, proofing_method=proofing_method, proofing_version=proofing_version, called_directly=called_directly
+            user, created_by, proofing_method=proofing_method, proofing_version=proofing_version
         )
         self._required_keys.extend(['orcid', 'issuer', 'audience'])
         self._data['orcid'] = orcid
@@ -493,7 +487,7 @@ class SwedenConnectProofing(NinProofingLogElement):
     }
     """
 
-    def __init__(self, user, created_by, nin, issuer, authn_context_class, user_postal_address, proofing_version, called_directly=True):
+    def __init__(self, user, created_by, nin, issuer, authn_context_class, user_postal_address, proofing_version):
         """
         :param user: user object
         :param created_by: Application creating the log element
@@ -521,7 +515,6 @@ class SwedenConnectProofing(NinProofingLogElement):
             user_postal_address,
             proofing_method='swedenconnect',
             proofing_version=proofing_version,
-            called_directly=called_directly
         )
         self._required_keys.extend(['issuer', 'authn_context_class'])
         self._data['issuer'] = issuer
@@ -545,7 +538,7 @@ class MFATokenProofing(SwedenConnectProofing):
     """
 
     def __init__(
-        self, user, created_by, nin, issuer, authn_context_class, key_id, user_postal_address, proofing_version, called_directly=True
+        self, user, created_by, nin, issuer, authn_context_class, key_id, user_postal_address, proofing_version
     ):
         """
         :param user: user object
@@ -570,7 +563,7 @@ class MFATokenProofing(SwedenConnectProofing):
         :rtype: MFATokenProofing
         """
         super(MFATokenProofing, self).__init__(
-            user, created_by, nin, issuer, authn_context_class, user_postal_address, proofing_version=proofing_version, called_directly=called_directly
+            user, created_by, nin, issuer, authn_context_class, user_postal_address, proofing_version=proofing_version
         )
         self._required_keys.extend(['key_id'])
         self._data['key_id'] = key_id

--- a/src/eduid_userdb/logs/element.py
+++ b/src/eduid_userdb/logs/element.py
@@ -29,7 +29,7 @@ class LogElement(Element):
         self._required_keys = ['created_by', 'created_ts']
         # Since log elements are already nearer dataclasses than the rest of elements,
         # we do not deprecate direct calls to their __init__, which is close to what a dataclass would provide.
-        super(LogElement, self).__init__(data={'created_by': created_by, 'created_ts': True}, called_directly=False)
+        super().__init__(data={'created_by': created_by, 'created_ts': True}, called_directly=False)
 
     def validate(self):
         # Check that all keys are accounted for and that no string values are blank

--- a/src/eduid_userdb/logs/element.py
+++ b/src/eduid_userdb/logs/element.py
@@ -5,6 +5,7 @@
 
 from __future__ import absolute_import
 
+from typing import Any, Dict, Optional
 import logging
 
 import six
@@ -17,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 class LogElement(Element):
-    def __init__(self, created_by):
+    def __init__(self, created_by: Optional[str] = None, data: Optional[Dict[str, Any]] = None, called_directly: bool = True):
         """
         :param created_by: Application creating the log element
 
@@ -27,7 +28,12 @@ class LogElement(Element):
         :rtype: LogElement
         """
         self._required_keys = ['created_by', 'created_ts']
-        super(LogElement, self).__init__(data={'created_by': created_by, 'created_ts': True})
+        if data is None:
+            data = {'created_by': created_by, 'created_ts': True}
+        else:
+            data['created_ts'] = True
+
+        super(LogElement, self).__init__(data=data, called_directly=called_directly)
 
     def validate(self):
         # Check that all keys are accounted for and that no string values are blank
@@ -48,7 +54,7 @@ class LogElement(Element):
 
 
 class ProofingLogElement(LogElement):
-    def __init__(self, user, created_by, proofing_method, proofing_version):
+    def __init__(self, user, created_by, proofing_method, proofing_version, called_directly=True):
         """
         :param user: User object
         :param created_by: Application creating the log element
@@ -63,7 +69,7 @@ class ProofingLogElement(LogElement):
         :return: ProofingLogElement object
         :rtype: ProofingLogElement
         """
-        super(ProofingLogElement, self).__init__(created_by)
+        super(ProofingLogElement, self).__init__(created_by=created_by, called_directly=called_directly)
         self._required_keys.extend(['eduPersonPrincipalName', 'proofing_method', 'proofing_version'])
         self._data['eduPersonPrincipalName'] = user.eppn
         self._data['proofing_method'] = proofing_method
@@ -71,7 +77,7 @@ class ProofingLogElement(LogElement):
 
 
 class NinProofingLogElement(ProofingLogElement):
-    def __init__(self, user, created_by, nin, user_postal_address, proofing_method, proofing_version):
+    def __init__(self, user, created_by, nin, user_postal_address, proofing_method, proofing_version, called_directly=True):
         """
         :param user: user object
         :param created_by: Application creating the log element
@@ -89,7 +95,7 @@ class NinProofingLogElement(ProofingLogElement):
         :rtype: NinProofingLogElement
         """
         super(NinProofingLogElement, self).__init__(
-            user, created_by, proofing_method=proofing_method, proofing_version=proofing_version
+            user, created_by, proofing_method=proofing_method, proofing_version=proofing_version, called_directly=called_directly
         )
         self._required_keys.extend(['nin', 'user_postal_address'])
         self._data['nin'] = nin
@@ -113,7 +119,7 @@ class MailAddressProofing(ProofingLogElement):
     }
     """
 
-    def __init__(self, user, created_by, mail_address, reference, proofing_version):
+    def __init__(self, user, created_by, mail_address, reference, proofing_version, called_directly=True):
         """
         :param user: User object
         :param created_by: Application creating the log element
@@ -131,7 +137,7 @@ class MailAddressProofing(ProofingLogElement):
         :rtype: MailAddressProofing
         """
         super(MailAddressProofing, self).__init__(
-            user, created_by, proofing_method='e-mail', proofing_version=proofing_version
+            user, created_by, proofing_method='e-mail', proofing_version=proofing_version, called_directly=called_directly
         )
         self._required_keys.extend(['mail_address', 'reference'])
         self._data['mail_address'] = mail_address
@@ -151,7 +157,7 @@ class PhoneNumberProofing(ProofingLogElement):
     }
     """
 
-    def __init__(self, user, created_by, phone_number, reference, proofing_version):
+    def __init__(self, user, created_by, phone_number, reference, proofing_version, called_directly=True):
         """
         :param user: User object
         :param created_by: Application creating the log element
@@ -169,7 +175,7 @@ class PhoneNumberProofing(ProofingLogElement):
         :rtype: PhoneNumberProofing
         """
         super(PhoneNumberProofing, self).__init__(
-            user, created_by, proofing_method='sms', proofing_version=proofing_version
+            user, created_by, proofing_method='sms', proofing_version=proofing_version, called_directly=called_directly
         )
         self._required_keys.extend(['phone_number', 'reference'])
         self._data['phone_number'] = phone_number
@@ -192,7 +198,7 @@ class TeleAdressProofing(NinProofingLogElement):
     }
     """
 
-    def __init__(self, user, created_by, reason, nin, mobile_number, user_postal_address, proofing_version):
+    def __init__(self, user, created_by, reason, nin, mobile_number, user_postal_address, proofing_version, called_directly=True):
         """
         :param user: user object
         :param created_by: Application creating the log element
@@ -214,7 +220,7 @@ class TeleAdressProofing(NinProofingLogElement):
         :rtype: TeleAdressProofing
         """
         super(TeleAdressProofing, self).__init__(
-            user, created_by, nin, user_postal_address, proofing_method='TeleAdress', proofing_version=proofing_version
+            user, created_by, nin, user_postal_address, proofing_method='TeleAdress', proofing_version=proofing_version, called_directly=called_directly
         )
         self._required_keys.extend(['reason', 'mobile_number'])
         self._data['reason'] = reason
@@ -252,6 +258,7 @@ class TeleAdressProofingRelation(TeleAdressProofing):
         registered_relation,
         registered_postal_address,
         proofing_version,
+        called_directly=True,
     ):
         """
         :param user: user object
@@ -280,7 +287,7 @@ class TeleAdressProofingRelation(TeleAdressProofing):
         :rtype: TeleAdressProofingRelation
         """
         super(TeleAdressProofingRelation, self).__init__(
-            user, created_by, reason, nin, mobile_number, user_postal_address, proofing_version=proofing_version
+            user, created_by, reason, nin, mobile_number, user_postal_address, proofing_version=proofing_version, called_directly=called_directly
         )
         self._required_keys.extend(['mobile_number_registered_to', 'registered_relation', 'registered_postal_address'])
         self._data['mobile_number_registered_to'] = mobile_number_registered_to
@@ -303,7 +310,7 @@ class LetterProofing(NinProofingLogElement):
     }
     """
 
-    def __init__(self, user, created_by, nin, letter_sent_to, transaction_id, user_postal_address, proofing_version):
+    def __init__(self, user, created_by, nin, letter_sent_to, transaction_id, user_postal_address, proofing_version, called_directly=True):
         """
         :param user: user object
         :param created_by: Application creating the log element
@@ -325,7 +332,7 @@ class LetterProofing(NinProofingLogElement):
         :rtype: LetterProofing
         """
         super(LetterProofing, self).__init__(
-            user, created_by, nin, user_postal_address, proofing_method='letter', proofing_version=proofing_version
+            user, created_by, nin, user_postal_address, proofing_method='letter', proofing_version=proofing_version, called_directly=called_directly
         )
         self._required_keys.extend(['proofing_method', 'letter_sent_to', 'transaction_id'])
         self._data['letter_sent_to'] = letter_sent_to
@@ -347,7 +354,7 @@ class SeLegProofing(NinProofingLogElement):
     }
     """
 
-    def __init__(self, user, created_by, nin, vetting_by, transaction_id, user_postal_address, proofing_version):
+    def __init__(self, user, created_by, nin, vetting_by, transaction_id, user_postal_address, proofing_version, called_directly=True):
         """
         :param user: user object
         :param created_by: Application creating the log element
@@ -369,7 +376,7 @@ class SeLegProofing(NinProofingLogElement):
         :rtype: SeLegProofing
         """
         super(SeLegProofing, self).__init__(
-            user, created_by, nin, user_postal_address, proofing_method='se-leg', proofing_version=proofing_version
+            user, created_by, nin, user_postal_address, proofing_method='se-leg', proofing_version=proofing_version, called_directly=called_directly
         )
         self._required_keys.extend(['proofing_method', 'vetting_by', 'transaction_id'])
         self._data['vetting_by'] = vetting_by
@@ -392,7 +399,7 @@ class SeLegProofingFrejaEid(SeLegProofing):
     }
     """
 
-    def __init__(self, user, created_by, nin, transaction_id, opaque_data, user_postal_address, proofing_version):
+    def __init__(self, user, created_by, nin, transaction_id, opaque_data, user_postal_address, proofing_version, called_directly=True):
         """
         :param user: user object
         :param created_by: Application creating the log element
@@ -421,6 +428,7 @@ class SeLegProofingFrejaEid(SeLegProofing):
             transaction_id=transaction_id,
             user_postal_address=user_postal_address,
             proofing_version=proofing_version,
+            called_directly=called_directly
         )
         self._required_keys.extend(['opaque_data'])
         self._data['opaque_data'] = opaque_data
@@ -440,7 +448,7 @@ class OrcidProofing(ProofingLogElement):
     }
     """
 
-    def __init__(self, user, created_by, orcid, issuer, audience, proofing_method, proofing_version):
+    def __init__(self, user, created_by, orcid, issuer, audience, proofing_method, proofing_version, called_directly=True):
         """
         :param user: User object
         :param created_by: Application creating the log element
@@ -462,7 +470,7 @@ class OrcidProofing(ProofingLogElement):
         :rtype: ProofingLogElement
         """
         super(OrcidProofing, self).__init__(
-            user, created_by, proofing_method=proofing_method, proofing_version=proofing_version
+            user, created_by, proofing_method=proofing_method, proofing_version=proofing_version, called_directly=called_directly
         )
         self._required_keys.extend(['orcid', 'issuer', 'audience'])
         self._data['orcid'] = orcid
@@ -485,7 +493,7 @@ class SwedenConnectProofing(NinProofingLogElement):
     }
     """
 
-    def __init__(self, user, created_by, nin, issuer, authn_context_class, user_postal_address, proofing_version):
+    def __init__(self, user, created_by, nin, issuer, authn_context_class, user_postal_address, proofing_version, called_directly=True):
         """
         :param user: user object
         :param created_by: Application creating the log element
@@ -513,6 +521,7 @@ class SwedenConnectProofing(NinProofingLogElement):
             user_postal_address,
             proofing_method='swedenconnect',
             proofing_version=proofing_version,
+            called_directly=called_directly
         )
         self._required_keys.extend(['issuer', 'authn_context_class'])
         self._data['issuer'] = issuer
@@ -536,7 +545,7 @@ class MFATokenProofing(SwedenConnectProofing):
     """
 
     def __init__(
-        self, user, created_by, nin, issuer, authn_context_class, key_id, user_postal_address, proofing_version
+        self, user, created_by, nin, issuer, authn_context_class, key_id, user_postal_address, proofing_version, called_directly=True
     ):
         """
         :param user: user object
@@ -561,7 +570,7 @@ class MFATokenProofing(SwedenConnectProofing):
         :rtype: MFATokenProofing
         """
         super(MFATokenProofing, self).__init__(
-            user, created_by, nin, issuer, authn_context_class, user_postal_address, proofing_version=proofing_version
+            user, created_by, nin, issuer, authn_context_class, user_postal_address, proofing_version=proofing_version, called_directly=called_directly
         )
         self._required_keys.extend(['key_id'])
         self._data['key_id'] = key_id

--- a/src/eduid_userdb/mail.py
+++ b/src/eduid_userdb/mail.py
@@ -79,13 +79,6 @@ class MailAddress(PrimaryElement):
         PrimaryElement.__init__(self, data, raise_on_unknown, called_directly=called_directly, ignore_data=['email'])
         self.email = data.pop('email')
 
-    @classmethod
-    def from_dict(cls: Type[TElementSubclass], data: Dict[str, Any], raise_on_unknown: bool = True) -> TElementSubclass:
-        """
-        Construct user from a data dict.
-        """
-        return cls(data=data, raise_on_unknown=raise_on_unknown, called_directly=False)
-
     # -----------------------------------------------------------------
     @property
     def key(self):

--- a/src/eduid_userdb/mail.py
+++ b/src/eduid_userdb/mail.py
@@ -77,7 +77,7 @@ class MailAddress(PrimaryElement):
         # CSRF tokens were accidentally put in the database some time ago
         if 'csrf' in data:
             del data['csrf']
-        PrimaryElement.__init__(self, data, raise_on_unknown, called_directly=called_directly, ignore_data=['email'])
+        super().__init__(data, raise_on_unknown, called_directly=called_directly, ignore_data=['email'])
         self.email = data.pop('email')
 
     # -----------------------------------------------------------------

--- a/src/eduid_userdb/mail.py
+++ b/src/eduid_userdb/mail.py
@@ -60,6 +60,7 @@ class MailAddress(PrimaryElement):
         primary=None,
         data=None,
         raise_on_unknown=True,
+        called_directly=True,
     ):
         data_in = data
         data = copy.copy(data_in)  # to not modify callers data
@@ -74,7 +75,7 @@ class MailAddress(PrimaryElement):
         # CSRF tokens were accidentally put in the database some time ago
         if 'csrf' in data:
             del data['csrf']
-        PrimaryElement.__init__(self, data, raise_on_unknown, ignore_data=['email'])
+        PrimaryElement.__init__(self, data, raise_on_unknown, called_directly=called_directly, ignore_data=['email'])
         self.email = data.pop('email')
 
     # -----------------------------------------------------------------

--- a/src/eduid_userdb/mail.py
+++ b/src/eduid_userdb/mail.py
@@ -33,11 +33,10 @@
 #
 
 import copy
-from typing import Any, Dict, Type
 
 from six import string_types
 
-from eduid_userdb.element import PrimaryElement, PrimaryElementList, TElementSubclass
+from eduid_userdb.element import PrimaryElement, PrimaryElementList
 from eduid_userdb.exceptions import UserDBValueError
 
 __author__ = 'ft'

--- a/src/eduid_userdb/mail.py
+++ b/src/eduid_userdb/mail.py
@@ -33,10 +33,11 @@
 #
 
 import copy
+from typing import Any, Dict, Type
 
 from six import string_types
 
-from eduid_userdb.element import PrimaryElement, PrimaryElementList
+from eduid_userdb.element import PrimaryElement, PrimaryElementList, TElementSubclass
 from eduid_userdb.exceptions import UserDBValueError
 
 __author__ = 'ft'
@@ -77,6 +78,13 @@ class MailAddress(PrimaryElement):
             del data['csrf']
         PrimaryElement.__init__(self, data, raise_on_unknown, called_directly=called_directly, ignore_data=['email'])
         self.email = data.pop('email')
+
+    @classmethod
+    def from_dict(cls: Type[TElementSubclass], data: Dict[str, Any], raise_on_unknown: bool = True) -> TElementSubclass:
+        """
+        Construct user from a data dict.
+        """
+        return cls(data=data, raise_on_unknown=raise_on_unknown, called_directly=False)
 
     # -----------------------------------------------------------------
     @property
@@ -200,23 +208,4 @@ def address_from_dict(data, raise_on_unknown=True):
     :type raise_on_unknown: bool
     :rtype: MailAddress
     """
-    return MailAddress(data=data, raise_on_unknown=raise_on_unknown)
-
-
-def new(email, application, verified=False, created_ts=None):
-    """
-    Create a new MailAddress object.
-
-    :param email: E-mail address
-    :param application: Name of creating application ('signup', ...)
-    :param verified: Declare e-mail address verified/confirmed
-    :param created_ts: Timestamp of creation (or None to use current time)
-
-    :type email: str | unicode
-    :type application: str | unicode
-    :type verified: bool
-    :type created_ts: None | datetime.datetime
-
-    :return: New MailAddress instance
-    :rtype: MailAddress
-    """
+    return MailAddress.from_dict(data, raise_on_unknown=raise_on_unknown)

--- a/src/eduid_userdb/mail.py
+++ b/src/eduid_userdb/mail.py
@@ -33,6 +33,8 @@
 #
 
 import copy
+from datetime import datetime
+from typing import Any, Dict, Optional, Union
 
 from six import string_types
 
@@ -53,14 +55,14 @@ class MailAddress(PrimaryElement):
 
     def __init__(
         self,
-        email=None,
-        application=None,
-        verified=False,
-        created_ts=None,
-        primary=None,
-        data=None,
-        raise_on_unknown=True,
-        called_directly=True,
+        email: Optional[str] = None,
+        application: Optional[str] = None,
+        verified: bool = False,
+        created_ts: Optional[Union[datetime, bool]] = None,
+        primary: bool = False,
+        data: Optional[Dict[str, Any]] = None,
+        raise_on_unknown: bool = True,
+        called_directly: bool = True,
     ):
         data_in = data
         data = copy.copy(data_in)  # to not modify callers data

--- a/src/eduid_userdb/nin.py
+++ b/src/eduid_userdb/nin.py
@@ -33,10 +33,12 @@
 #
 
 import copy
+from typing import Any, Dict, Type
 
 from six import string_types
 
 from eduid_userdb.element import PrimaryElement, PrimaryElementList
+from eduid_userdb.element import TElementSubclass
 from eduid_userdb.exceptions import UserDBValueError
 
 __author__ = 'ft'
@@ -74,6 +76,13 @@ class Nin(PrimaryElement):
 
         PrimaryElement.__init__(self, data, raise_on_unknown, called_directly=called_directly, ignore_data=['number'])
         self.number = data.pop('number')
+
+    @classmethod
+    def from_dict(cls: Type[TElementSubclass], data: Dict[str, Any], raise_on_unknown: bool = True) -> TElementSubclass:
+        """
+        Construct user from a data dict.
+        """
+        return cls(data=data, raise_on_unknown=raise_on_unknown, called_directly=False)
 
     # -----------------------------------------------------------------
     @property
@@ -181,4 +190,4 @@ def nin_from_dict(data, raise_on_unknown=True):
     :type raise_on_unknown: bool
     :rtype: Nin
     """
-    return Nin(data=data, raise_on_unknown=raise_on_unknown)
+    return Nin.from_dict(data, raise_on_unknown=raise_on_unknown)

--- a/src/eduid_userdb/nin.py
+++ b/src/eduid_userdb/nin.py
@@ -60,6 +60,7 @@ class Nin(PrimaryElement):
         primary=None,
         data=None,
         raise_on_unknown=True,
+        called_directly=True,
     ):
         data_in = data
         data = copy.copy(data_in)  # to not modify callers data
@@ -71,7 +72,7 @@ class Nin(PrimaryElement):
                 number=number, created_by=application, created_ts=created_ts, verified=verified, primary=primary,
             )
 
-        PrimaryElement.__init__(self, data, raise_on_unknown, ignore_data=['number'])
+        PrimaryElement.__init__(self, data, raise_on_unknown, called_directly=called_directly, ignore_data=['number'])
         self.number = data.pop('number')
 
     # -----------------------------------------------------------------

--- a/src/eduid_userdb/nin.py
+++ b/src/eduid_userdb/nin.py
@@ -33,9 +33,9 @@
 #
 
 import copy
-
 from datetime import datetime
 from typing import Any, Dict, Optional, Union
+
 from six import string_types
 
 from eduid_userdb.element import PrimaryElement, PrimaryElementList

--- a/src/eduid_userdb/nin.py
+++ b/src/eduid_userdb/nin.py
@@ -34,6 +34,8 @@
 
 import copy
 
+from datetime import datetime
+from typing import Any, Dict, Optional, Union
 from six import string_types
 
 from eduid_userdb.element import PrimaryElement, PrimaryElementList
@@ -53,14 +55,14 @@ class Nin(PrimaryElement):
 
     def __init__(
         self,
-        number=None,
-        application=None,
-        verified=False,
-        created_ts=None,
-        primary=None,
-        data=None,
-        raise_on_unknown=True,
-        called_directly=True,
+        number: Optional[str] = None,
+        application: Optional[str] = None,
+        verified: bool = False,
+        created_ts: Optional[Union[datetime, bool]] = None,
+        primary: bool = False,
+        data: Optional[Dict[str, Any]] = None,
+        raise_on_unknown: bool = True,
+        called_directly: bool = True,
     ):
         data_in = data
         data = copy.copy(data_in)  # to not modify callers data

--- a/src/eduid_userdb/nin.py
+++ b/src/eduid_userdb/nin.py
@@ -37,8 +37,7 @@ from typing import Any, Dict, Type
 
 from six import string_types
 
-from eduid_userdb.element import PrimaryElement, PrimaryElementList
-from eduid_userdb.element import TElementSubclass
+from eduid_userdb.element import PrimaryElement, PrimaryElementList, TElementSubclass
 from eduid_userdb.exceptions import UserDBValueError
 
 __author__ = 'ft'

--- a/src/eduid_userdb/nin.py
+++ b/src/eduid_userdb/nin.py
@@ -76,13 +76,6 @@ class Nin(PrimaryElement):
         PrimaryElement.__init__(self, data, raise_on_unknown, called_directly=called_directly, ignore_data=['number'])
         self.number = data.pop('number')
 
-    @classmethod
-    def from_dict(cls: Type[TElementSubclass], data: Dict[str, Any], raise_on_unknown: bool = True) -> TElementSubclass:
-        """
-        Construct user from a data dict.
-        """
-        return cls(data=data, raise_on_unknown=raise_on_unknown, called_directly=False)
-
     # -----------------------------------------------------------------
     @property
     def key(self):

--- a/src/eduid_userdb/nin.py
+++ b/src/eduid_userdb/nin.py
@@ -33,11 +33,10 @@
 #
 
 import copy
-from typing import Any, Dict, Type
 
 from six import string_types
 
-from eduid_userdb.element import PrimaryElement, PrimaryElementList, TElementSubclass
+from eduid_userdb.element import PrimaryElement, PrimaryElementList
 from eduid_userdb.exceptions import UserDBValueError
 
 __author__ = 'ft'

--- a/src/eduid_userdb/nin.py
+++ b/src/eduid_userdb/nin.py
@@ -74,7 +74,7 @@ class Nin(PrimaryElement):
                 number=number, created_by=application, created_ts=created_ts, verified=verified, primary=primary,
             )
 
-        PrimaryElement.__init__(self, data, raise_on_unknown, called_directly=called_directly, ignore_data=['number'])
+        super().__init__(data, raise_on_unknown, called_directly=called_directly, ignore_data=['number'])
         self.number = data.pop('number')
 
     # -----------------------------------------------------------------

--- a/src/eduid_userdb/orcid.py
+++ b/src/eduid_userdb/orcid.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import copy
-from typing import Any, Dict, Optional, Type
+from typing import Any, Dict, Type
 
 from six import string_types
 
@@ -13,21 +13,7 @@ from eduid_userdb.exceptions import UserDBValueError, UserHasUnknownData
 __author__ = 'lundberg'
 
 
-class OidcElement(Element):
-    def __init__(
-        self, data: Optional[Dict[str, Any]] = None, raise_on_unknown: bool = True, called_directly: bool = True,
-    ):
-        raise NotImplementedError()
-
-    @classmethod
-    def from_dict(cls: Type[OidcElement], data: Dict[str, Any], raise_on_unknown: bool = True) -> OidcElement:
-        """
-        Construct user from a data dict.
-        """
-        return cls(data=data, called_directly=False, raise_on_unknown=raise_on_unknown)
-
-
-class OidcIdToken(OidcElement):
+class OidcIdToken(Element):
     """
     OpenID Connect ID token data
     """
@@ -73,7 +59,7 @@ class OidcIdToken(OidcElement):
         elif 'created_ts' not in data:
             data['created_ts'] = True
 
-        Element.__init__(self, data, called_directly=called_directly)
+        super().__init__(data, called_directly=called_directly)
         self.iss = data.pop('iss')
         self.sub = data.pop('sub')
         self.aud = data.pop('aud')
@@ -87,6 +73,13 @@ class OidcIdToken(OidcElement):
 
         if raise_on_unknown and data:
             raise UserHasUnknownData('{!s} has unknown data: {!r}'.format(self.__class__.__name__, data.keys()))
+
+    @classmethod
+    def from_dict(cls: Type[OidcIdToken], data: Dict[str, Any], raise_on_unknown: bool = True) -> OidcIdToken:
+        """
+        Construct user from a data dict.
+        """
+        return cls(data=data, called_directly=False, raise_on_unknown=raise_on_unknown)
 
     @property
     def key(self):
@@ -312,7 +305,7 @@ class OidcIdToken(OidcElement):
             self._data['azp'] = value
 
 
-class OidcAuthorization(OidcElement):
+class OidcAuthorization(Element):
     """
     OpenID Connect Authorization data
     """
@@ -348,7 +341,7 @@ class OidcAuthorization(OidcElement):
         elif 'created_ts' not in data:
             data['created_ts'] = True
 
-        Element.__init__(self, data, called_directly=called_directly)
+        super().__init__(data, called_directly=called_directly)
         self.access_token = data.pop('access_token')
         self.token_type = data.pop('token_type')
         self.expires_in = data.pop('expires_in')
@@ -363,6 +356,13 @@ class OidcAuthorization(OidcElement):
 
         if raise_on_unknown and data:
             raise UserHasUnknownData('{!s} has unknown data: {!r}'.format(self.__class__.__name__, data.keys()))
+
+    @classmethod
+    def from_dict(cls: Type[OidcAuthorization], data: Dict[str, Any], raise_on_unknown: bool = True) -> OidcAuthorization:
+        """
+        Construct user from a data dict.
+        """
+        return cls(data=data, called_directly=False, raise_on_unknown=raise_on_unknown)
 
     @property
     def key(self):

--- a/src/eduid_userdb/orcid.py
+++ b/src/eduid_userdb/orcid.py
@@ -57,6 +57,9 @@ class OidcIdToken(Element):
                 created_by=application,
                 created_ts=created_ts,
             )
+        elif 'created_ts' not in data:
+            data['created_ts'] = True
+
         Element.__init__(self, data, called_directly=called_directly)
         self.iss = data.pop('iss')
         self.sub = data.pop('sub')
@@ -319,6 +322,7 @@ class OidcAuthorization(Element):
         created_ts=None,
         data=None,
         raise_on_unknown=True,
+        called_directly=True,
     ):
         data_in = data
         data = copy.deepcopy(data_in)  # to not modify callers data
@@ -335,8 +339,10 @@ class OidcAuthorization(Element):
                 created_by=application,
                 created_ts=created_ts,
             )
+        elif 'created_ts' not in data:
+            data['created_ts'] = True
 
-        Element.__init__(self, data)
+        Element.__init__(self, data, called_directly=called_directly)
         self.access_token = data.pop('access_token')
         self.token_type = data.pop('token_type')
         self.expires_in = data.pop('expires_in')
@@ -521,6 +527,8 @@ class Orcid(VerifiedElement):
                 created_ts=created_ts,
                 verified=verified,
             )
+        elif 'created_ts' not in data:
+            data['created_ts'] = True
 
         VerifiedElement.__init__(self, data, called_directly=called_directly)
         self.id = data.pop('id')

--- a/src/eduid_userdb/orcid.py
+++ b/src/eduid_userdb/orcid.py
@@ -74,13 +74,6 @@ class OidcIdToken(Element):
         if raise_on_unknown and data:
             raise UserHasUnknownData('{!s} has unknown data: {!r}'.format(self.__class__.__name__, data.keys()))
 
-    @classmethod
-    def from_dict(cls: Type[TElementSubclass], data: Dict[str, Any], raise_on_unknown: bool = True) -> TElementSubclass:
-        """
-        Construct user from a data dict.
-        """
-        return cls(data=data, raise_on_unknown=raise_on_unknown, called_directly=False)
-
     @property
     def key(self):
         """
@@ -356,13 +349,6 @@ class OidcAuthorization(Element):
 
         if raise_on_unknown and data:
             raise UserHasUnknownData('{!s} has unknown data: {!r}'.format(self.__class__.__name__, data.keys()))
-
-    @classmethod
-    def from_dict(cls: Type[TElementSubclass], data: Dict[str, Any], raise_on_unknown: bool = True) -> TElementSubclass:
-        """
-        Construct user from a data dict.
-        """
-        return cls(data=data, called_directly=False, raise_on_unknown=raise_on_unknown)
 
     @property
     def key(self):

--- a/src/eduid_userdb/orcid.py
+++ b/src/eduid_userdb/orcid.py
@@ -3,17 +3,38 @@
 from __future__ import absolute_import
 
 import copy
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Dict, Type, TypeVar
 
 from six import string_types
 
-from eduid_userdb.element import Element, TElementSubclass, VerifiedElement
+from eduid_userdb.element import Element, TPrimaryElementSubclass, VerifiedElement
 from eduid_userdb.exceptions import UserDBValueError, UserHasUnknownData
 
 __author__ = 'lundberg'
 
 
-class OidcIdToken(Element):
+TOidcSubclass = TypeVar('TOidcSubclass', bound='OidcElement')
+
+
+class OidcElement(Element):
+
+    def __init__(
+        self,
+        data=None,
+        raise_on_unknown=True,
+        called_directly=True,
+    ):
+        raise NotImplementedError()
+
+    @classmethod
+    def from_dict(cls: Type[TOidcSubclass], data: Dict[str, Any], raise_on_unknown: bool = True) -> TOidcSubclass:
+        """
+        Construct user from a data dict.
+        """
+        return cls(data=data, called_directly=False, raise_on_unknown=raise_on_unknown)
+
+
+class OidcIdToken(OidcElement):
     """
     OpenID Connect ID token data
     """
@@ -298,7 +319,7 @@ class OidcIdToken(Element):
             self._data['azp'] = value
 
 
-class OidcAuthorization(Element):
+class OidcAuthorization(OidcElement):
     """
     OpenID Connect Authorization data
     """
@@ -480,6 +501,9 @@ class OidcAuthorization(Element):
         return data
 
 
+TOrcidSubclass = TypeVar('TOrcidSubclass', bound='Orcid')
+
+
 class Orcid(VerifiedElement):
     """
     :param data: Orcid parameters from database
@@ -537,6 +561,13 @@ class Orcid(VerifiedElement):
 
         if raise_on_unknown and data:
             raise UserHasUnknownData('{!s} has unknown data: {!r}'.format(self.__class__.__name__, data.keys()))
+
+    @classmethod
+    def from_dict(cls: Type['Orcid'], data: Dict[str, Any], raise_on_unknown: bool = True) -> 'Orcid':
+        """
+        Construct user from a data dict.
+        """
+        return cls(data=data, called_directly=False, raise_on_unknown=raise_on_unknown)
 
     # -----------------------------------------------------------------
     @property

--- a/src/eduid_userdb/orcid.py
+++ b/src/eduid_userdb/orcid.py
@@ -7,8 +7,7 @@ from typing import Any, Dict, List, Optional, Type
 
 from six import string_types
 
-from eduid_userdb.element import Element, VerifiedElement
-from eduid_userdb.element import TElementSubclass
+from eduid_userdb.element import Element, TElementSubclass, VerifiedElement
 from eduid_userdb.exceptions import UserDBValueError, UserHasUnknownData
 
 __author__ = 'lundberg'

--- a/src/eduid_userdb/orcid.py
+++ b/src/eduid_userdb/orcid.py
@@ -17,12 +17,8 @@ TOidcSubclass = TypeVar('TOidcSubclass', bound='OidcElement')
 
 
 class OidcElement(Element):
-
     def __init__(
-        self,
-        data=None,
-        raise_on_unknown=True,
-        called_directly=True,
+        self, data=None, raise_on_unknown=True, called_directly=True,
     ):
         raise NotImplementedError()
 

--- a/src/eduid_userdb/orcid.py
+++ b/src/eduid_userdb/orcid.py
@@ -546,7 +546,7 @@ class Orcid(VerifiedElement):
         # Parse ID token
         _oidc_authz = data.pop('oidc_authz')
         if isinstance(_oidc_authz, dict):
-            self.oidc_authz = OidcAuthorization(data=_oidc_authz)
+            self.oidc_authz = OidcAuthorization.from_dict(_oidc_authz)
         if isinstance(_oidc_authz, OidcAuthorization):
             self.oidc_authz = _oidc_authz
 

--- a/src/eduid_userdb/orcid.py
+++ b/src/eduid_userdb/orcid.py
@@ -15,7 +15,7 @@ __author__ = 'lundberg'
 
 class OidcElement(Element):
     def __init__(
-            self, data: Optional[Dict[str, Any]] = None, raise_on_unknown: bool = True, called_directly: bool = True,
+        self, data: Optional[Dict[str, Any]] = None, raise_on_unknown: bool = True, called_directly: bool = True,
     ):
         raise NotImplementedError()
 

--- a/src/eduid_userdb/orcid.py
+++ b/src/eduid_userdb/orcid.py
@@ -3,27 +3,24 @@
 from __future__ import absolute_import
 
 import copy
-from typing import Any, Dict, Type, TypeVar
+from typing import Any, Dict, Optional, Type
 
 from six import string_types
 
-from eduid_userdb.element import Element, TPrimaryElementSubclass, VerifiedElement
+from eduid_userdb.element import Element, VerifiedElement
 from eduid_userdb.exceptions import UserDBValueError, UserHasUnknownData
 
 __author__ = 'lundberg'
 
 
-TOidcSubclass = TypeVar('TOidcSubclass', bound='OidcElement')
-
-
 class OidcElement(Element):
     def __init__(
-        self, data=None, raise_on_unknown=True, called_directly=True,
+            self, data: Optional[Dict[str, Any]] = None, raise_on_unknown: bool = True, called_directly: bool = True,
     ):
         raise NotImplementedError()
 
     @classmethod
-    def from_dict(cls: Type[TOidcSubclass], data: Dict[str, Any], raise_on_unknown: bool = True) -> TOidcSubclass:
+    def from_dict(cls: Type['OidcElement'], data: Dict[str, Any], raise_on_unknown: bool = True) -> 'OidcElement':
         """
         Construct user from a data dict.
         """
@@ -495,9 +492,6 @@ class OidcAuthorization(OidcElement):
         data = copy.deepcopy(self._data)
         data['id_token'] = self.id_token.to_dict()
         return data
-
-
-TOrcidSubclass = TypeVar('TOrcidSubclass', bound='Orcid')
 
 
 class Orcid(VerifiedElement):

--- a/src/eduid_userdb/orcid.py
+++ b/src/eduid_userdb/orcid.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
+from __future__ import annotations
 
 import copy
 from typing import Any, Dict, Optional, Type
@@ -20,7 +20,7 @@ class OidcElement(Element):
         raise NotImplementedError()
 
     @classmethod
-    def from_dict(cls: Type['OidcElement'], data: Dict[str, Any], raise_on_unknown: bool = True) -> 'OidcElement':
+    def from_dict(cls: Type[OidcElement], data: Dict[str, Any], raise_on_unknown: bool = True) -> OidcElement:
         """
         Construct user from a data dict.
         """
@@ -536,7 +536,7 @@ class Orcid(VerifiedElement):
         elif 'created_ts' not in data:
             data['created_ts'] = True
 
-        VerifiedElement.__init__(self, data, called_directly=called_directly)
+        super().__init__(data, called_directly=called_directly)
         self.id = data.pop('id')
         self.name = data.pop('name', None)
         self.given_name = data.pop('given_name', None)

--- a/src/eduid_userdb/orcid.py
+++ b/src/eduid_userdb/orcid.py
@@ -358,6 +358,13 @@ class OidcAuthorization(Element):
         if raise_on_unknown and data:
             raise UserHasUnknownData('{!s} has unknown data: {!r}'.format(self.__class__.__name__, data.keys()))
 
+    @classmethod
+    def from_dict(cls: Type[TElementSubclass], data: Dict[str, Any], raise_on_unknown: bool = True) -> TElementSubclass:
+        """
+        Construct user from a data dict.
+        """
+        return cls(data=data, called_directly=False, raise_on_unknown=raise_on_unknown)
+
     @property
     def key(self):
         """

--- a/src/eduid_userdb/phone.py
+++ b/src/eduid_userdb/phone.py
@@ -33,6 +33,8 @@
 #
 
 import copy
+from datetime import datetime
+from typing import Any, Dict, Optional, Union
 
 from six import string_types
 
@@ -53,14 +55,14 @@ class PhoneNumber(PrimaryElement):
 
     def __init__(
         self,
-        number=None,
-        application=None,
-        verified=False,
-        created_ts=None,
-        primary=False,
-        data=None,
-        raise_on_unknown=True,
-        called_directly=True,
+        number: Optional[str] = None,
+        application: Optional[str] = None,
+        verified: bool = False,
+        created_ts: Optional[Union[datetime, bool]] = None,
+        primary: bool = False,
+        data: Optional[Dict[str, Any]] = None,
+        raise_on_unknown: bool = True,
+        called_directly: bool = True,
     ):
         data_in = data
         data = copy.copy(data_in)  # to not modify callers data

--- a/src/eduid_userdb/phone.py
+++ b/src/eduid_userdb/phone.py
@@ -60,6 +60,7 @@ class PhoneNumber(PrimaryElement):
         primary=False,
         data=None,
         raise_on_unknown=True,
+        called_directly=True,
     ):
         data_in = data
         data = copy.copy(data_in)  # to not modify callers data
@@ -82,7 +83,7 @@ class PhoneNumber(PrimaryElement):
         if 'csrf' in data:
             del data['csrf']
 
-        PrimaryElement.__init__(self, data, raise_on_unknown, ignore_data=['number'])
+        PrimaryElement.__init__(self, data, raise_on_unknown, called_directly=called_directly, ignore_data=['number'])
         self.number = data.pop('number')
 
     # -----------------------------------------------------------------

--- a/src/eduid_userdb/phone.py
+++ b/src/eduid_userdb/phone.py
@@ -87,13 +87,6 @@ class PhoneNumber(PrimaryElement):
         PrimaryElement.__init__(self, data, raise_on_unknown, called_directly=called_directly, ignore_data=['number'])
         self.number = data.pop('number')
 
-    @classmethod
-    def from_dict(cls: Type[TElementSubclass], data: Dict[str, Any], raise_on_unknown: bool = True) -> TElementSubclass:
-        """
-        Construct user from a data dict.
-        """
-        return cls(data=data, raise_on_unknown=raise_on_unknown, called_directly=False)
-
     # -----------------------------------------------------------------
     @property
     def key(self):

--- a/src/eduid_userdb/phone.py
+++ b/src/eduid_userdb/phone.py
@@ -85,7 +85,7 @@ class PhoneNumber(PrimaryElement):
         if 'csrf' in data:
             del data['csrf']
 
-        PrimaryElement.__init__(self, data, raise_on_unknown, called_directly=called_directly, ignore_data=['number'])
+        super().__init__(data, raise_on_unknown, called_directly=called_directly, ignore_data=['number'])
         self.number = data.pop('number')
 
     # -----------------------------------------------------------------

--- a/src/eduid_userdb/phone.py
+++ b/src/eduid_userdb/phone.py
@@ -37,8 +37,7 @@ from typing import Any, Dict, Type
 
 from six import string_types
 
-from eduid_userdb.element import PrimaryElement, PrimaryElementList
-from eduid_userdb.element import TElementSubclass
+from eduid_userdb.element import PrimaryElement, PrimaryElementList, TElementSubclass
 from eduid_userdb.exceptions import UserDBValueError
 
 __author__ = 'ft'

--- a/src/eduid_userdb/phone.py
+++ b/src/eduid_userdb/phone.py
@@ -33,11 +33,10 @@
 #
 
 import copy
-from typing import Any, Dict, Type
 
 from six import string_types
 
-from eduid_userdb.element import PrimaryElement, PrimaryElementList, TElementSubclass
+from eduid_userdb.element import PrimaryElement, PrimaryElementList
 from eduid_userdb.exceptions import UserDBValueError
 
 __author__ = 'ft'

--- a/src/eduid_userdb/phone.py
+++ b/src/eduid_userdb/phone.py
@@ -33,10 +33,12 @@
 #
 
 import copy
+from typing import Any, Dict, Type
 
 from six import string_types
 
 from eduid_userdb.element import PrimaryElement, PrimaryElementList
+from eduid_userdb.element import TElementSubclass
 from eduid_userdb.exceptions import UserDBValueError
 
 __author__ = 'ft'
@@ -85,6 +87,13 @@ class PhoneNumber(PrimaryElement):
 
         PrimaryElement.__init__(self, data, raise_on_unknown, called_directly=called_directly, ignore_data=['number'])
         self.number = data.pop('number')
+
+    @classmethod
+    def from_dict(cls: Type[TElementSubclass], data: Dict[str, Any], raise_on_unknown: bool = True) -> TElementSubclass:
+        """
+        Construct user from a data dict.
+        """
+        return cls(data=data, raise_on_unknown=raise_on_unknown, called_directly=False)
 
     # -----------------------------------------------------------------
     @property
@@ -198,4 +207,4 @@ def phone_from_dict(data, raise_on_unknown=True):
     :type raise_on_unknown: bool
     :rtype: PhoneNumber
     """
-    return PhoneNumber(data=data, raise_on_unknown=raise_on_unknown)
+    return PhoneNumber.from_dict(data, raise_on_unknown=raise_on_unknown)

--- a/src/eduid_userdb/profile.py
+++ b/src/eduid_userdb/profile.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, List, Mapping, Optional, Union
+from typing import Any, Dict, List, Mapping, Optional, Union
 
 from eduid_userdb.element import DuplicateElementViolation, Element, ElementList
 from eduid_userdb.exceptions import UserDBValueError
@@ -20,7 +20,7 @@ class Profile(Element):
         created_by: Optional[str] = None,
         created_ts: Optional[Union[datetime, bool]] = None,
         modified_ts: Optional[Union[datetime, bool]] = None,
-        data: Optional[Mapping[str, Any]] = None,
+        data: Optional[Dict[str, Any]] = None,
         called_directly: bool = True,
     ):
 
@@ -35,12 +35,15 @@ class Profile(Element):
 
         super().__init__(data=data, called_directly=called_directly)
 
-        self.owner = owner
-        self.schema = schema
-        self.profile_data = profile_data
+        if owner is not None:
+            self.owner = owner
+        if schema is not None:
+            self.schema = schema
+        if profile_data is not None:
+            self.profile_data = profile_data
 
     @classmethod
-    def from_dict(cls, data: Mapping[str, Any]) -> Profile:
+    def from_dict(cls, data: Dict[str, Any]) -> Profile:
         return cls(data=data, called_directly=False)
 
     # -----------------------------------------------------------------
@@ -111,7 +114,7 @@ class ProfileList(ElementList):
             self.add(profile)
 
     @classmethod
-    def from_list_of_dicts(cls, items: List[Mapping[str, Any]]) -> ProfileList:
+    def from_list_of_dicts(cls, items: List[Dict[str, Any]]) -> ProfileList:
         profiles = list()
         for item in items:
             profiles.append(Profile.from_dict(item))

--- a/src/eduid_userdb/profile.py
+++ b/src/eduid_userdb/profile.py
@@ -14,18 +14,26 @@ __author__ = 'lundberg'
 class Profile(Element):
     def __init__(
         self,
-        owner: str,
-        schema: str,
-        profile_data: Mapping[str, Any],
+        owner: Optional[str] = None,
+        schema: Optional[str] = None,
+        profile_data: Optional[Mapping[str, Any]] = None,
         created_by: Optional[str] = None,
         created_ts: Optional[Union[datetime, bool]] = None,
         modified_ts: Optional[Union[datetime, bool]] = None,
+        data: Optional[Mapping[str, Any]] = None,
+        called_directly: bool = True,
     ):
 
         if created_ts is None:
             created_ts = True
-        data = dict(created_by=created_by, created_ts=created_ts, modified_ts=modified_ts)
-        super().__init__(data=data)
+        if data is None:
+            data = dict(created_by=created_by, created_ts=created_ts, modified_ts=modified_ts)
+        else:
+            owner = data.pop('owner')
+            schema = data.pop('schema')
+            profile_data = data.pop('profile_data')
+
+        super().__init__(data=data, called_directly=called_directly)
 
         self.owner = owner
         self.schema = schema
@@ -33,7 +41,7 @@ class Profile(Element):
 
     @classmethod
     def from_dict(cls, data: Mapping[str, Any]) -> Profile:
-        return cls(**data)
+        return cls(data=data, called_directly=False)
 
     # -----------------------------------------------------------------
     @property
@@ -106,5 +114,5 @@ class ProfileList(ElementList):
     def from_list_of_dicts(cls, items: List[Mapping[str, Any]]) -> ProfileList:
         profiles = list()
         for item in items:
-            profiles.append(Profile.from_dict(data=item))
+            profiles.append(Profile.from_dict(item))
         return cls(profiles=profiles)

--- a/src/eduid_userdb/profile.py
+++ b/src/eduid_userdb/profile.py
@@ -21,6 +21,7 @@ class Profile(Element):
         created_ts: Optional[Union[datetime, bool]] = None,
         modified_ts: Optional[Union[datetime, bool]] = None,
         data: Optional[Dict[str, Any]] = None,
+        raise_on_unknown: bool = True,
         called_directly: bool = True,
     ):
 
@@ -41,10 +42,6 @@ class Profile(Element):
             self.schema = schema
         if profile_data is not None:
             self.profile_data = profile_data
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> Profile:
-        return cls(data=data, called_directly=False)
 
     # -----------------------------------------------------------------
     @property

--- a/src/eduid_userdb/profile.py
+++ b/src/eduid_userdb/profile.py
@@ -14,34 +14,24 @@ __author__ = 'lundberg'
 class Profile(Element):
     def __init__(
         self,
-        owner: Optional[str] = None,
-        schema: Optional[str] = None,
-        profile_data: Optional[Mapping[str, Any]] = None,
+        owner: str,
+        schema: str,
+        profile_data: Mapping[str, Any],
         created_by: Optional[str] = None,
         created_ts: Optional[Union[datetime, bool]] = None,
         modified_ts: Optional[Union[datetime, bool]] = None,
-        data: Optional[Dict[str, Any]] = None,
-        raise_on_unknown: bool = True,
-        called_directly: bool = True,
     ):
 
         if created_ts is None:
             created_ts = True
-        if data is None:
-            data = dict(created_by=created_by, created_ts=created_ts, modified_ts=modified_ts)
-        else:
-            owner = data.pop('owner')
-            schema = data.pop('schema')
-            profile_data = data.pop('profile_data')
+        data = dict(created_by=created_by, created_ts=created_ts, modified_ts=modified_ts)
+        # do not deprecate direct calls to the __init__ of Profile,
+        # since it does not accept a data dict, and is already very near a dataclass
+        super().__init__(data=data, called_directly=False)
 
-        super().__init__(data=data, called_directly=called_directly)
-
-        if owner is not None:
-            self.owner = owner
-        if schema is not None:
-            self.schema = schema
-        if profile_data is not None:
-            self.profile_data = profile_data
+        self.owner = owner
+        self.schema = schema
+        self.profile_data = profile_data
 
     # -----------------------------------------------------------------
     @property
@@ -114,5 +104,5 @@ class ProfileList(ElementList):
     def from_list_of_dicts(cls, items: List[Dict[str, Any]]) -> ProfileList:
         profiles = list()
         for item in items:
-            profiles.append(Profile.from_dict(item))
+            profiles.append(Profile(**item))
         return cls(profiles=profiles)

--- a/src/eduid_userdb/proofing/element.py
+++ b/src/eduid_userdb/proofing/element.py
@@ -69,7 +69,6 @@ class ProofingElement(VerifiedElement):
         verified_ts=None,
         verification_code=None,
         data=None,
-        raise_on_unknown=True,
         called_directly=True,
     ):
 
@@ -87,7 +86,7 @@ class ProofingElement(VerifiedElement):
                 verification_code=verification_code,
             )
         verification_code = data_in.pop('verification_code', None)
-        VerifiedElement.__init__(self, data_in, raise_on_unknown=raise_on_unknown, called_directly=called_directly)
+        VerifiedElement.__init__(self, data_in, called_directly=called_directly)
         self.verification_code = verification_code
 
     @property
@@ -138,7 +137,6 @@ class NinProofingElement(ProofingElement):
         verified=False,
         verification_code=None,
         data=None,
-        raise_on_unknown=True,
         called_directly=True,
     ):
 
@@ -152,7 +150,6 @@ class NinProofingElement(ProofingElement):
             verified=verified,
             verification_code=verification_code,
             data=data,
-            raise_on_unknown=raise_on_unknown,
             called_directly=called_directly,
         )
         self.number = number
@@ -210,7 +207,6 @@ class EmailProofingElement(ProofingElement):
         verified=False,
         verification_code=None,
         data=None,
-        raise_on_unknown=True,
         called_directly=True,
     ):
 
@@ -224,7 +220,6 @@ class EmailProofingElement(ProofingElement):
             verified=verified,
             verification_code=verification_code,
             data=data,
-            raise_on_unknown=raise_on_unknown,
             called_directly=called_directly,
         )
         self.email = email
@@ -282,7 +277,6 @@ class PhoneProofingElement(ProofingElement):
         verified=False,
         verification_code=None,
         data=None,
-        raise_on_unknown=True,
         called_directly=True,
     ):
 
@@ -296,7 +290,6 @@ class PhoneProofingElement(ProofingElement):
             verified=verified,
             verification_code=verification_code,
             data=data,
-            raise_on_unknown=raise_on_unknown,
             called_directly=called_directly,
         )
         self.number = phone
@@ -339,9 +332,9 @@ class SentLetterElement(Element):
     created_ts
     """
 
-    def __init__(self, data, raise_on_unknown=True, called_directly=True):
+    def __init__(self, data, called_directly=True):
         super(SentLetterElement, self).__init__(
-            data, raise_on_unknown=raise_on_unknown, called_directly=called_directly
+            data, called_directly=called_directly
         )
 
         self._data['is_sent'] = data.pop('is_sent', False)

--- a/src/eduid_userdb/proofing/element.py
+++ b/src/eduid_userdb/proofing/element.py
@@ -130,7 +130,14 @@ class NinProofingElement(ProofingElement):
     """
 
     def __init__(
-        self, number=None, application=None, created_ts=None, verified=False, verification_code=None, data=None, called_directly=True,
+        self,
+        number=None,
+        application=None,
+        created_ts=None,
+        verified=False,
+        verification_code=None,
+        data=None,
+        called_directly=True,
     ):
 
         data = copy.copy(data)
@@ -193,7 +200,14 @@ class EmailProofingElement(ProofingElement):
     """
 
     def __init__(
-        self, email=None, application=None, created_ts=None, verified=False, verification_code=None, data=None, called_directly=True,
+        self,
+        email=None,
+        application=None,
+        created_ts=None,
+        verified=False,
+        verification_code=None,
+        data=None,
+        called_directly=True,
     ):
 
         data = copy.copy(data)
@@ -256,7 +270,14 @@ class PhoneProofingElement(ProofingElement):
     """
 
     def __init__(
-        self, phone=None, application=None, created_ts=None, verified=False, verification_code=None, data=None, called_directly=True,
+        self,
+        phone=None,
+        application=None,
+        created_ts=None,
+        verified=False,
+        verification_code=None,
+        data=None,
+        called_directly=True,
     ):
 
         data = copy.copy(data)

--- a/src/eduid_userdb/proofing/element.py
+++ b/src/eduid_userdb/proofing/element.py
@@ -333,9 +333,7 @@ class SentLetterElement(Element):
     """
 
     def __init__(self, data, called_directly=True):
-        super(SentLetterElement, self).__init__(
-            data, called_directly=called_directly
-        )
+        super(SentLetterElement, self).__init__(data, called_directly=called_directly)
 
         self._data['is_sent'] = data.pop('is_sent', False)
         self._data['sent_ts'] = data.pop('sent_ts', None)

--- a/src/eduid_userdb/proofing/element.py
+++ b/src/eduid_userdb/proofing/element.py
@@ -69,6 +69,7 @@ class ProofingElement(VerifiedElement):
         verified_ts=None,
         verification_code=None,
         data=None,
+        called_directly=True,
     ):
 
         data_in = copy.copy(data)  # to not modify callers data
@@ -85,7 +86,7 @@ class ProofingElement(VerifiedElement):
                 verification_code=verification_code,
             )
         verification_code = data_in.pop('verification_code', None)
-        VerifiedElement.__init__(self, data_in)
+        VerifiedElement.__init__(self, data_in, called_directly=called_directly)
         self.verification_code = verification_code
 
     @property
@@ -129,7 +130,7 @@ class NinProofingElement(ProofingElement):
     """
 
     def __init__(
-        self, number=None, application=None, created_ts=None, verified=False, verification_code=None, data=None
+        self, number=None, application=None, created_ts=None, verified=False, verification_code=None, data=None, called_directly=True,
     ):
 
         data = copy.copy(data)
@@ -142,6 +143,7 @@ class NinProofingElement(ProofingElement):
             verified=verified,
             verification_code=verification_code,
             data=data,
+            called_directly=called_directly,
         )
         self.number = number
 
@@ -191,7 +193,7 @@ class EmailProofingElement(ProofingElement):
     """
 
     def __init__(
-        self, email=None, application=None, created_ts=None, verified=False, verification_code=None, data=None
+        self, email=None, application=None, created_ts=None, verified=False, verification_code=None, data=None, called_directly=True,
     ):
 
         data = copy.copy(data)
@@ -204,6 +206,7 @@ class EmailProofingElement(ProofingElement):
             verified=verified,
             verification_code=verification_code,
             data=data,
+            called_directly=called_directly,
         )
         self.email = email
 
@@ -253,7 +256,7 @@ class PhoneProofingElement(ProofingElement):
     """
 
     def __init__(
-        self, phone=None, application=None, created_ts=None, verified=False, verification_code=None, data=None
+        self, phone=None, application=None, created_ts=None, verified=False, verification_code=None, data=None, called_directly=True,
     ):
 
         data = copy.copy(data)
@@ -266,6 +269,7 @@ class PhoneProofingElement(ProofingElement):
             verified=verified,
             verification_code=verification_code,
             data=data,
+            called_directly=called_directly,
         )
         self.number = phone
 
@@ -307,8 +311,8 @@ class SentLetterElement(Element):
     created_ts
     """
 
-    def __init__(self, data):
-        super(SentLetterElement, self).__init__(data)
+    def __init__(self, data, called_directly=True):
+        super(SentLetterElement, self).__init__(data, called_directly=called_directly)
 
         self._data['is_sent'] = data.pop('is_sent', False)
         self._data['sent_ts'] = data.pop('sent_ts', None)

--- a/src/eduid_userdb/proofing/element.py
+++ b/src/eduid_userdb/proofing/element.py
@@ -340,7 +340,9 @@ class SentLetterElement(Element):
     """
 
     def __init__(self, data, raise_on_unknown=True, called_directly=True):
-        super(SentLetterElement, self).__init__(data, raise_on_unknown=raise_on_unknown, called_directly=called_directly)
+        super(SentLetterElement, self).__init__(
+            data, raise_on_unknown=raise_on_unknown, called_directly=called_directly
+        )
 
         self._data['is_sent'] = data.pop('is_sent', False)
         self._data['sent_ts'] = data.pop('sent_ts', None)

--- a/src/eduid_userdb/proofing/element.py
+++ b/src/eduid_userdb/proofing/element.py
@@ -69,6 +69,7 @@ class ProofingElement(VerifiedElement):
         verified_ts=None,
         verification_code=None,
         data=None,
+        raise_on_unknown=True,
         called_directly=True,
     ):
 
@@ -86,7 +87,7 @@ class ProofingElement(VerifiedElement):
                 verification_code=verification_code,
             )
         verification_code = data_in.pop('verification_code', None)
-        VerifiedElement.__init__(self, data_in, called_directly=called_directly)
+        VerifiedElement.__init__(self, data_in, raise_on_unknown=raise_on_unknown, called_directly=called_directly)
         self.verification_code = verification_code
 
     @property
@@ -137,6 +138,7 @@ class NinProofingElement(ProofingElement):
         verified=False,
         verification_code=None,
         data=None,
+        raise_on_unknown=True,
         called_directly=True,
     ):
 
@@ -150,6 +152,7 @@ class NinProofingElement(ProofingElement):
             verified=verified,
             verification_code=verification_code,
             data=data,
+            raise_on_unknown=raise_on_unknown,
             called_directly=called_directly,
         )
         self.number = number
@@ -207,6 +210,7 @@ class EmailProofingElement(ProofingElement):
         verified=False,
         verification_code=None,
         data=None,
+        raise_on_unknown=True,
         called_directly=True,
     ):
 
@@ -220,6 +224,7 @@ class EmailProofingElement(ProofingElement):
             verified=verified,
             verification_code=verification_code,
             data=data,
+            raise_on_unknown=raise_on_unknown,
             called_directly=called_directly,
         )
         self.email = email
@@ -277,6 +282,7 @@ class PhoneProofingElement(ProofingElement):
         verified=False,
         verification_code=None,
         data=None,
+        raise_on_unknown=True,
         called_directly=True,
     ):
 
@@ -290,6 +296,7 @@ class PhoneProofingElement(ProofingElement):
             verified=verified,
             verification_code=verification_code,
             data=data,
+            raise_on_unknown=raise_on_unknown,
             called_directly=called_directly,
         )
         self.number = phone
@@ -332,8 +339,8 @@ class SentLetterElement(Element):
     created_ts
     """
 
-    def __init__(self, data, called_directly=True):
-        super(SentLetterElement, self).__init__(data, called_directly=called_directly)
+    def __init__(self, data, raise_on_unknown=True, called_directly=True):
+        super(SentLetterElement, self).__init__(data, raise_on_unknown=raise_on_unknown, called_directly=called_directly)
 
         self._data['is_sent'] = data.pop('is_sent', False)
         self._data['sent_ts'] = data.pop('sent_ts', None)

--- a/src/eduid_userdb/proofing/element.py
+++ b/src/eduid_userdb/proofing/element.py
@@ -86,7 +86,7 @@ class ProofingElement(VerifiedElement):
                 verification_code=verification_code,
             )
         verification_code = data_in.pop('verification_code', None)
-        VerifiedElement.__init__(self, data_in, called_directly=called_directly)
+        super().__init__(data_in, called_directly=called_directly)
         self.verification_code = verification_code
 
     @property
@@ -333,7 +333,7 @@ class SentLetterElement(Element):
     """
 
     def __init__(self, data, called_directly=True):
-        super(SentLetterElement, self).__init__(data, called_directly=called_directly)
+        super().__init__(data, called_directly=called_directly)
 
         self._data['is_sent'] = data.pop('is_sent', False)
         self._data['sent_ts'] = data.pop('sent_ts', None)

--- a/src/eduid_userdb/reset_password/element.py
+++ b/src/eduid_userdb/reset_password/element.py
@@ -47,7 +47,6 @@ class CodeElement(Element):
         verified: Optional[bool] = None,
         created_ts: Optional[Union[datetime, bool]] = None,
         data: Optional[Dict[str, Any]] = None,
-        raise_on_unknown: bool = True,
         called_directly: bool = True,
     ):
 
@@ -57,7 +56,7 @@ class CodeElement(Element):
             code = data.pop('code')
             verified = data.pop('verified')
 
-        super().__init__(data, raise_on_unknown=raise_on_unknown, called_directly=called_directly)
+        super().__init__(data, called_directly=called_directly)
 
         if code is not None:
             self.code = code

--- a/src/eduid_userdb/reset_password/element.py
+++ b/src/eduid_userdb/reset_password/element.py
@@ -33,17 +33,22 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import Mapping, Type, Union
+from typing import Any, Dict, Mapping, Optional, Type, Union
 
 from eduid_userdb.element import Element
 from eduid_userdb.exceptions import UserDBValueError
 
 
 class CodeElement(Element):
-    def __init__(self, application: str, code: str, verified: bool, created_ts: Union[datetime, bool]):
+    def __init__(self, application: Optional[str] = None, code: Optional[str] = None, verified: Optional[bool] = None, created_ts: Optional[Union[datetime, bool]] = None, data: Optional[Dict[str, Any]] = None, called_directly: bool = True):
 
-        data = dict(created_by=application, created_ts=created_ts,)
-        super().__init__(data)
+        if data is None:
+            data = dict(created_by=application, created_ts=created_ts,)
+        else:
+            code = data.pop('code')
+            verified = data.pop('verified')
+
+        super().__init__(data, called_directly=called_directly)
 
         self.code = code
         self.is_verified = verified
@@ -95,17 +100,19 @@ class CodeElement(Element):
         cls: Type[CodeElement], code_or_element: Union[Mapping, CodeElement, str], application: str
     ) -> CodeElement:
         if isinstance(code_or_element, str):
-            return cls(application=application, code=code_or_element, created_ts=True, verified=False)
+            return cls.from_dict(dict(application=application, code=code_or_element, created_ts=True, verified=False))
         if isinstance(code_or_element, dict):
             data = code_or_element
             for this in data.keys():
                 if this not in ['application', 'code', 'created_by', 'created_ts', 'verified']:
                     raise ValueError(f'Unknown data {this} for CodeElement.parse from mapping')
-            return cls(
-                application=data.get('created_by', application),
-                code=data['code'],
-                created_ts=data.get('created_ts', True),
-                verified=data.get('verified', False),
+            return cls.from_dict(
+                dict(
+                    application=data.get('created_by', application),
+                    code=data['code'],
+                    created_ts=data.get('created_ts', True),
+                    verified=data.get('verified', False),
+                )
             )
         if isinstance(code_or_element, CodeElement):
             return code_or_element

--- a/src/eduid_userdb/reset_password/element.py
+++ b/src/eduid_userdb/reset_password/element.py
@@ -40,7 +40,15 @@ from eduid_userdb.exceptions import UserDBValueError
 
 
 class CodeElement(Element):
-    def __init__(self, application: Optional[str] = None, code: Optional[str] = None, verified: Optional[bool] = None, created_ts: Optional[Union[datetime, bool]] = None, data: Optional[Dict[str, Any]] = None, called_directly: bool = True):
+    def __init__(
+        self,
+        application: Optional[str] = None,
+        code: Optional[str] = None,
+        verified: Optional[bool] = None,
+        created_ts: Optional[Union[datetime, bool]] = None,
+        data: Optional[Dict[str, Any]] = None,
+        called_directly: bool = True,
+    ):
 
         if data is None:
             data = dict(created_by=application, created_ts=created_ts,)

--- a/src/eduid_userdb/reset_password/element.py
+++ b/src/eduid_userdb/reset_password/element.py
@@ -47,6 +47,7 @@ class CodeElement(Element):
         verified: Optional[bool] = None,
         created_ts: Optional[Union[datetime, bool]] = None,
         data: Optional[Dict[str, Any]] = None,
+        raise_on_unknown: bool = True,
         called_directly: bool = True,
     ):
 
@@ -56,7 +57,7 @@ class CodeElement(Element):
             code = data.pop('code')
             verified = data.pop('verified')
 
-        super().__init__(data, called_directly=called_directly)
+        super().__init__(data, raise_on_unknown=raise_on_unknown, called_directly=called_directly)
 
         if code is not None:
             self.code = code

--- a/src/eduid_userdb/reset_password/element.py
+++ b/src/eduid_userdb/reset_password/element.py
@@ -58,8 +58,10 @@ class CodeElement(Element):
 
         super().__init__(data, called_directly=called_directly)
 
-        self.code = code
-        self.is_verified = verified
+        if code is not None:
+            self.code = code
+        if verified is not None:
+            self.is_verified = verified
 
     @property
     def key(self) -> str:

--- a/src/eduid_userdb/reset_password/element.py
+++ b/src/eduid_userdb/reset_password/element.py
@@ -33,35 +33,20 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import Any, Dict, Mapping, Optional, Type, Union
+from typing import Mapping, Type, Union
 
 from eduid_userdb.element import Element
 from eduid_userdb.exceptions import UserDBValueError
 
 
 class CodeElement(Element):
-    def __init__(
-        self,
-        application: Optional[str] = None,
-        code: Optional[str] = None,
-        verified: Optional[bool] = None,
-        created_ts: Optional[Union[datetime, bool]] = None,
-        data: Optional[Dict[str, Any]] = None,
-        called_directly: bool = True,
-    ):
+    def __init__(self, application: str, code: str, verified: bool, created_ts: Union[datetime, bool]):
 
-        if data is None:
-            data = dict(created_by=application, created_ts=created_ts,)
-        else:
-            code = data.pop('code')
-            verified = data.pop('verified')
+        data = dict(created_by=application, created_ts=created_ts,)
+        super().__init__(data)
 
-        super().__init__(data, called_directly=called_directly)
-
-        if code is not None:
-            self.code = code
-        if verified is not None:
-            self.is_verified = verified
+        self.code = code
+        self.is_verified = verified
 
     @property
     def key(self) -> str:
@@ -110,19 +95,17 @@ class CodeElement(Element):
         cls: Type[CodeElement], code_or_element: Union[Mapping, CodeElement, str], application: str
     ) -> CodeElement:
         if isinstance(code_or_element, str):
-            return cls.from_dict(dict(application=application, code=code_or_element, created_ts=True, verified=False))
+            return cls(application=application, code=code_or_element, created_ts=True, verified=False)
         if isinstance(code_or_element, dict):
             data = code_or_element
             for this in data.keys():
                 if this not in ['application', 'code', 'created_by', 'created_ts', 'verified']:
                     raise ValueError(f'Unknown data {this} for CodeElement.parse from mapping')
-            return cls.from_dict(
-                dict(
-                    application=data.get('created_by', application),
-                    code=data['code'],
-                    created_ts=data.get('created_ts', True),
-                    verified=data.get('verified', False),
-                )
+            return cls(
+                application=data.get('created_by', application),
+                code=data['code'],
+                created_ts=data.get('created_ts', True),
+                verified=data.get('verified', False),
             )
         if isinstance(code_or_element, CodeElement):
             return code_or_element

--- a/src/eduid_userdb/signup/user.py
+++ b/src/eduid_userdb/signup/user.py
@@ -71,7 +71,7 @@ class SignupUser(User):
         _proofing_reference = data.pop('proofing_reference', None)
         if _pending_mail_address:
             if isinstance(_pending_mail_address, dict):
-                _pending_mail_address = EmailProofingElement(data=_pending_mail_address)
+                _pending_mail_address = EmailProofingElement.from_dict(_pending_mail_address)
 
         self.social_network = _social_network
         self.social_network_id = _social_network_id

--- a/src/eduid_userdb/tests/test_event.py
+++ b/src/eduid_userdb/tests/test_event.py
@@ -83,7 +83,7 @@ class TestEventList(TestCase):
     def test_add_duplicate_key(self):
         data = deepcopy(_two_dict)
         data['version'] = 'other version'
-        dup = ToUEvent(data=data)
+        dup = ToUEvent.from_dict(data)
         with self.assertRaises(eduid_userdb.element.DuplicateElementViolation):
             self.two.add(dup)
 
@@ -97,7 +97,7 @@ class TestEventList(TestCase):
             'id': bson.ObjectId(),
             'salt': 'foo',
         }
-        new = Password(data=pwdict)
+        new = Password.from_dict(pwdict)
         with self.assertRaises(eduid_userdb.element.UserDBValueError):
             self.one.add(new)
 

--- a/src/eduid_userdb/tests/test_mail.py
+++ b/src/eduid_userdb/tests/test_mail.py
@@ -86,7 +86,7 @@ class TestMailAddressList(TestCase):
             'id': bson.ObjectId(),
             'salt': 'foo',
         }
-        new = Password(data=pwdict)
+        new = Password.from_dict(pwdict)
         with self.assertRaises(eduid_userdb.element.UserDBValueError):
             self.one.add(new)
 

--- a/src/eduid_userdb/tests/test_mail.py
+++ b/src/eduid_userdb/tests/test_mail.py
@@ -186,12 +186,12 @@ class TestMailAddress(TestCase):
         one = copy.deepcopy(_one_dict)
         one['foo'] = 'bar'
         with self.assertRaises(eduid_userdb.exceptions.UserHasUnknownData):
-            MailAddress(data=one)
+            MailAddress.from_dict(one)
 
     def test_unknown_input_data_allowed(self):
         one = copy.deepcopy(_one_dict)
         one['foo'] = 'bar'
-        addr = MailAddress(data=one, raise_on_unknown=False)
+        addr = MailAddress.from_dict(data=one, raise_on_unknown=False)
         out = addr.to_dict()
         self.assertIn('foo', out)
         self.assertEqual(out['foo'], one['foo'])

--- a/src/eduid_userdb/tests/test_nin.py
+++ b/src/eduid_userdb/tests/test_nin.py
@@ -184,12 +184,12 @@ class TestNin(TestCase):
         one = copy.deepcopy(_one_dict)
         one['foo'] = 'bar'
         with self.assertRaises(eduid_userdb.exceptions.UserHasUnknownData):
-            Nin(data=one)
+            Nin.from_dict(one)
 
     def test_unknown_input_data_allowed(self):
         one = copy.deepcopy(_one_dict)
         one['foo'] = 'bar'
-        addr = Nin(data=one, raise_on_unknown=False)
+        addr = Nin.from_dict(one, raise_on_unknown=False)
         out = addr.to_dict()
         self.assertIn('foo', out)
         self.assertEqual(out['foo'], one['foo'])

--- a/src/eduid_userdb/tests/test_nin.py
+++ b/src/eduid_userdb/tests/test_nin.py
@@ -84,7 +84,7 @@ class TestNinList(TestCase):
             'id': bson.ObjectId(),
             'salt': 'foo',
         }
-        new = Password(data=pwdict)
+        new = Password.from_dict(pwdict)
         with self.assertRaises(eduid_userdb.element.UserDBValueError):
             self.one.add(new)
 

--- a/src/eduid_userdb/tests/test_orcid.py
+++ b/src/eduid_userdb/tests/test_orcid.py
@@ -37,16 +37,18 @@ class TestOrcid(TestCase):
         id_token_data = token_response['id_token']
         id_token_data['created_ts'] = True
         id_token_data['created_by'] = 'test'
-        id_token_1 = OidcIdToken(data=id_token_data, raise_on_unknown=False)
-        id_token_2 = OidcIdToken(
-            iss=id_token_data['iss'],
-            sub=id_token_data['sub'],
-            aud=id_token_data['aud'],
-            exp=id_token_data['exp'],
-            iat=id_token_data['iat'],
-            nonce=id_token_data['nonce'],
-            auth_time=id_token_data['auth_time'],
-            application='test',
+        id_token_1 = OidcIdToken.from_dict(id_token_data, raise_on_unknown=False)
+        id_token_2 = OidcIdToken.from_dict(
+            dict(
+                iss=id_token_data['iss'],
+                sub=id_token_data['sub'],
+                aud=id_token_data['aud'],
+                exp=id_token_data['exp'],
+                iat=id_token_data['iat'],
+                nonce=id_token_data['nonce'],
+                auth_time=id_token_data['auth_time'],
+                created_by='test',
+            )
         )
 
         self.assertIsInstance(id_token_1, OidcIdToken)
@@ -74,15 +76,17 @@ class TestOrcid(TestCase):
 
         token_response['created_ts'] = True
         token_response['created_by'] = 'test'
-        oidc_authz_1 = OidcAuthorization(data=token_response, raise_on_unknown=False)
-        oidc_authz_2 = OidcAuthorization(
-            access_token=token_response['access_token'],
-            token_type=token_response['token_type'],
-            id_token=id_token,
-            expires_in=token_response['expires_in'],
-            refresh_token=token_response['refresh_token'],
-            application='test',
-            created_ts=True,
+        oidc_authz_1 = OidcAuthorization.from_dict(token_response, raise_on_unknown=False)
+        oidc_authz_2 = OidcAuthorization.from_dict(
+            dict(
+                access_token=token_response['access_token'],
+                token_type=token_response['token_type'],
+                id_token=id_token,
+                expires_in=token_response['expires_in'],
+                refresh_token=token_response['refresh_token'],
+                created_by='test',
+                created_ts=True,
+            )
         )
 
         self.assertIsInstance(oidc_authz_1, OidcAuthorization)
@@ -110,10 +114,10 @@ class TestOrcid(TestCase):
         token_response['created_ts'] = True
         token_response['created_by'] = 'test'
         oidc_authz = OidcAuthorization(data=token_response, raise_on_unknown=False)
-        orcid_1 = Orcid(
-            id='https://op.example.org/user_orcid', oidc_authz=oidc_authz, application='test', verified=True
+        orcid_1 = Orcid.from_dict(
+            dict(id='https://op.example.org/user_orcid', oidc_authz=oidc_authz, created_by='test', verified=True)
         )
-        orcid_2 = Orcid(data=orcid_1.to_dict())
+        orcid_2 = Orcid.from_dict(data=orcid_1.to_dict())
 
         self.assertIsInstance(orcid_1, Orcid)
         self.assertIsInstance(orcid_1.to_dict(), dict)
@@ -137,7 +141,7 @@ class TestOrcid(TestCase):
         with self.assertRaises(eduid_userdb.exceptions.UserHasUnknownData):
             data = orcid_1.to_dict()
             data['unknown_key'] = 'test'
-            Orcid(data=data)
+            Orcid.from_dict(data)
 
         with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            Orcid()
+            Orcid.from_dict({})

--- a/src/eduid_userdb/tests/test_orcid.py
+++ b/src/eduid_userdb/tests/test_orcid.py
@@ -144,4 +144,4 @@ class TestOrcid(TestCase):
             Orcid.from_dict(data)
 
         with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            Orcid.from_dict({})
+            Orcid.from_dict(None)

--- a/src/eduid_userdb/tests/test_orcid.py
+++ b/src/eduid_userdb/tests/test_orcid.py
@@ -63,16 +63,16 @@ class TestOrcid(TestCase):
         self.assertEqual(dict_1, dict_2)
 
         with self.assertRaises(eduid_userdb.exceptions.UserHasUnknownData):
-            OidcIdToken(data=id_token_data)
+            OidcIdToken.from_dict(id_token_data)
 
         with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            OidcIdToken()
+            OidcIdToken.from_dict(None)
 
     def test_oidc_authz(self):
         id_token_data = token_response['id_token']
         id_token_data['created_ts'] = True
         id_token_data['created_by'] = 'test'
-        id_token = OidcIdToken(data=token_response['id_token'], raise_on_unknown=False)
+        id_token = OidcIdToken.from_dict(token_response['id_token'], raise_on_unknown=False)
 
         token_response['created_ts'] = True
         token_response['created_by'] = 'test'
@@ -103,17 +103,17 @@ class TestOrcid(TestCase):
         self.assertEqual(dict_1, dict_2)
 
         with self.assertRaises(eduid_userdb.exceptions.UserHasUnknownData):
-            OidcAuthorization(data=token_response)
+            OidcAuthorization.from_dict(token_response)
 
         with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            OidcAuthorization()
+            OidcAuthorization.from_dict(None)
 
     def test_orcid(self):
         token_response['id_token']['created_ts'] = True
         token_response['id_token']['created_by'] = 'test'
         token_response['created_ts'] = True
         token_response['created_by'] = 'test'
-        oidc_authz = OidcAuthorization(data=token_response, raise_on_unknown=False)
+        oidc_authz = OidcAuthorization.from_dict(token_response, raise_on_unknown=False)
         orcid_1 = Orcid.from_dict(
             dict(id='https://op.example.org/user_orcid', oidc_authz=oidc_authz, created_by='test', verified=True)
         )

--- a/src/eduid_userdb/tests/test_password.py
+++ b/src/eduid_userdb/tests/test_password.py
@@ -56,12 +56,12 @@ class TestPassword(TestCase):
         one = copy.deepcopy(_one_dict)
         one['foo'] = 'bar'
         with self.assertRaises(eduid_userdb.exceptions.UserHasUnknownData):
-            Password(data=one)
+            Password.from_dict(one)
 
     def test_unknown_input_data_allowed(self):
         one = copy.deepcopy(_one_dict)
         one['foo'] = 'bar'
-        addr = Password(data=one, raise_on_unknown=False)
+        addr = Password.from_dict(one, raise_on_unknown=False)
         out = addr.to_dict()
         self.assertIn('foo', out)
         self.assertEqual(out['foo'], one['foo'])

--- a/src/eduid_userdb/tests/test_phone.py
+++ b/src/eduid_userdb/tests/test_phone.py
@@ -91,7 +91,7 @@ class TestPhoneNumberList(TestCase):
             'id': bson.ObjectId(),
             'salt': 'foo',
         }
-        new = Password(data=pwdict)
+        new = Password.from_dict(pwdict)
         with self.assertRaises(eduid_userdb.element.UserDBValueError):
             self.one.add(new)
 
@@ -207,7 +207,7 @@ class TestPhoneNumber(TestCase):
 
     def test_create_phone_number(self):
         one = copy.deepcopy(_one_dict)
-        one = PhoneNumber(data=one)
+        one = PhoneNumber.from_dict(one)
         self.assertEqual(_one_dict, one.to_dict())
 
     def test_parse_cycle(self):
@@ -227,12 +227,12 @@ class TestPhoneNumber(TestCase):
         one = copy.deepcopy(_one_dict)
         one['foo'] = 'bar'
         with self.assertRaises(eduid_userdb.exceptions.UserHasUnknownData):
-            PhoneNumber(data=one)
+            PhoneNumber.from_dict(one)
 
     def test_unknown_input_data_allowed(self):
         one = copy.deepcopy(_one_dict)
         one['foo'] = 'bar'
-        addr = PhoneNumber(data=one, raise_on_unknown=False)
+        addr = PhoneNumber.from_dict(one, raise_on_unknown=False)
         out = addr.to_dict()
         self.assertIn('foo', out)
         self.assertEqual(out['foo'], one['foo'])

--- a/src/eduid_userdb/tests/test_profile.py
+++ b/src/eduid_userdb/tests/test_profile.py
@@ -28,18 +28,6 @@ class ProfileTest(TestCase):
             self.assertIn(key, profile.profile_data)
             self.assertEqual(value, profile.profile_data[key])
 
-    def test_create_profile_from_dict(self):
-        data = dict(owner='test owner', created_by='test created_by', created_ts=True, schema='test schema')
-        data['profile_data'] = OPAQUE_DATA
-        profile = Profile(**data)
-        self.assertEqual(profile.owner, 'test owner')
-        self.assertEqual(profile.schema, 'test schema')
-        self.assertEqual(profile.created_by, 'test created_by')
-        self.assertIsNotNone(profile.created_ts)
-        for key, value in OPAQUE_DATA.items():
-            self.assertIn(key, profile.profile_data)
-            self.assertEqual(value, profile.profile_data[key])
-
     def test_profile_list(self):
         profile = Profile(
             owner='test owner 1',
@@ -53,23 +41,6 @@ class ProfileTest(TestCase):
         profile2 = Profile(**data)
 
         profile_list = ProfileList([profile, profile2])
-        self.assertIsNotNone(profile_list)
-        self.assertEqual(profile_list.count, 2)
-        self.assertIsNotNone(profile_list.find('test owner 1'))
-        self.assertIsNotNone(profile_list.find('test owner 2'))
-
-    def test_profile_list_from_dicts(self):
-        data1 = dict(
-            owner='test owner 1',
-            schema='test schema',
-            profile_data=OPAQUE_DATA,
-            created_by='test created_by',
-            created_ts=True,
-        )
-        data2 = dict(owner='test owner 2', created_by='test created_by', created_ts=True, schema='test schema')
-        data2['profile_data'] = OPAQUE_DATA
-
-        profile_list = ProfileList.from_list_of_dicts([data1, data2])
         self.assertIsNotNone(profile_list)
         self.assertEqual(profile_list.count, 2)
         self.assertIsNotNone(profile_list.find('test owner 1'))

--- a/src/eduid_userdb/tests/test_profile.py
+++ b/src/eduid_userdb/tests/test_profile.py
@@ -36,9 +36,13 @@ class ProfileTest(TestCase):
             created_by='test created_by',
             created_ts=True,
         )
-        data = dict(owner='test owner 2', created_by='test created_by', created_ts=True, schema='test schema')
-        data['profile_data'] = OPAQUE_DATA
-        profile2 = Profile(**data)
+        profile2 = Profile(
+            owner='test owner 2',
+            created_by='test created_by',
+            created_ts=True,
+            schema='test schema',
+            profile_data=OPAQUE_DATA,
+        )
 
         profile_list = ProfileList([profile, profile2])
         self.assertIsNotNone(profile_list)

--- a/src/eduid_userdb/tests/test_profile.py
+++ b/src/eduid_userdb/tests/test_profile.py
@@ -13,12 +13,14 @@ OPAQUE_DATA = {'a_string': 'I am a string', 'an_int': 3, 'a_list': ['eins', 2, '
 
 class ProfileTest(TestCase):
     def test_create_profile(self):
-        profile = Profile(
-            owner='test owner',
-            schema='test schema',
-            profile_data=OPAQUE_DATA,
-            created_by='test created_by',
-            created_ts=True,
+        profile = Profile.from_dict(
+            dict(
+                owner='test owner',
+                schema='test schema',
+                profile_data=OPAQUE_DATA,
+                created_by='test created_by',
+                created_ts=True,
+            )
         )
         self.assertEqual(profile.owner, 'test owner')
         self.assertEqual(profile.schema, 'test schema')
@@ -31,7 +33,7 @@ class ProfileTest(TestCase):
     def test_create_profile_from_dict(self):
         data = dict(owner='test owner', created_by='test created_by', created_ts=True, schema='test schema')
         data['profile_data'] = OPAQUE_DATA
-        profile = Profile.from_dict(data=data)
+        profile = Profile.from_dict(data)
         self.assertEqual(profile.owner, 'test owner')
         self.assertEqual(profile.schema, 'test schema')
         self.assertEqual(profile.created_by, 'test created_by')
@@ -41,16 +43,18 @@ class ProfileTest(TestCase):
             self.assertEqual(value, profile.profile_data[key])
 
     def test_profile_list(self):
-        profile = Profile(
-            owner='test owner 1',
-            schema='test schema',
-            profile_data=OPAQUE_DATA,
-            created_by='test created_by',
-            created_ts=True,
+        profile = Profile.from_dict(
+            dict(
+                owner='test owner 1',
+                schema='test schema',
+                profile_data=OPAQUE_DATA,
+                created_by='test created_by',
+                created_ts=True,
+            )
         )
         data = dict(owner='test owner 2', created_by='test created_by', created_ts=True, schema='test schema')
         data['profile_data'] = OPAQUE_DATA
-        profile2 = Profile.from_dict(data=data)
+        profile2 = Profile.from_dict(data)
 
         profile_list = ProfileList([profile, profile2])
         self.assertIsNotNone(profile_list)
@@ -81,15 +85,17 @@ class ProfileTest(TestCase):
         self.assertEqual(profile_list.count, 0)
 
     def test_profile_list_owner_conflict(self):
-        profile = Profile(
-            owner='test owner 1',
-            schema='test schema',
-            profile_data=OPAQUE_DATA,
-            created_by='test created_by',
-            created_ts=True,
+        profile = Profile.from_dict(
+            dict(
+                owner='test owner 1',
+                schema='test schema',
+                profile_data=OPAQUE_DATA,
+                created_by='test created_by',
+                created_ts=True,
+            )
         )
         profile_dict = profile.to_dict()
-        profile2 = Profile.from_dict(data=profile_dict)
+        profile2 = Profile.from_dict(profile_dict)
 
         with self.assertRaises(DuplicateElementViolation):
             ProfileList([profile, profile2])

--- a/src/eduid_userdb/tests/test_profile.py
+++ b/src/eduid_userdb/tests/test_profile.py
@@ -13,14 +13,12 @@ OPAQUE_DATA = {'a_string': 'I am a string', 'an_int': 3, 'a_list': ['eins', 2, '
 
 class ProfileTest(TestCase):
     def test_create_profile(self):
-        profile = Profile.from_dict(
-            dict(
-                owner='test owner',
-                schema='test schema',
-                profile_data=OPAQUE_DATA,
-                created_by='test created_by',
-                created_ts=True,
-            )
+        profile = Profile(
+            owner='test owner',
+            schema='test schema',
+            profile_data=OPAQUE_DATA,
+            created_by='test created_by',
+            created_ts=True,
         )
         self.assertEqual(profile.owner, 'test owner')
         self.assertEqual(profile.schema, 'test schema')
@@ -33,7 +31,7 @@ class ProfileTest(TestCase):
     def test_create_profile_from_dict(self):
         data = dict(owner='test owner', created_by='test created_by', created_ts=True, schema='test schema')
         data['profile_data'] = OPAQUE_DATA
-        profile = Profile.from_dict(data)
+        profile = Profile(**data)
         self.assertEqual(profile.owner, 'test owner')
         self.assertEqual(profile.schema, 'test schema')
         self.assertEqual(profile.created_by, 'test created_by')
@@ -43,18 +41,16 @@ class ProfileTest(TestCase):
             self.assertEqual(value, profile.profile_data[key])
 
     def test_profile_list(self):
-        profile = Profile.from_dict(
-            dict(
-                owner='test owner 1',
-                schema='test schema',
-                profile_data=OPAQUE_DATA,
-                created_by='test created_by',
-                created_ts=True,
-            )
+        profile = Profile(
+            owner='test owner 1',
+            schema='test schema',
+            profile_data=OPAQUE_DATA,
+            created_by='test created_by',
+            created_ts=True,
         )
         data = dict(owner='test owner 2', created_by='test created_by', created_ts=True, schema='test schema')
         data['profile_data'] = OPAQUE_DATA
-        profile2 = Profile.from_dict(data)
+        profile2 = Profile(**data)
 
         profile_list = ProfileList([profile, profile2])
         self.assertIsNotNone(profile_list)
@@ -85,17 +81,15 @@ class ProfileTest(TestCase):
         self.assertEqual(profile_list.count, 0)
 
     def test_profile_list_owner_conflict(self):
-        profile = Profile.from_dict(
-            dict(
-                owner='test owner 1',
-                schema='test schema',
-                profile_data=OPAQUE_DATA,
-                created_by='test created_by',
-                created_ts=True,
-            )
+        profile = Profile(
+            owner='test owner 1',
+            schema='test schema',
+            profile_data=OPAQUE_DATA,
+            created_by='test created_by',
+            created_ts=True,
         )
         profile_dict = profile.to_dict()
-        profile2 = Profile.from_dict(profile_dict)
+        profile2 = Profile(**profile_dict)
 
         with self.assertRaises(DuplicateElementViolation):
             ProfileList([profile, profile2])

--- a/src/eduid_userdb/tests/test_proofing.py
+++ b/src/eduid_userdb/tests/test_proofing.py
@@ -97,7 +97,9 @@ class ProofingStateTest(TestCase):
         }
         """
 
-        nin_pe = NinProofingElement.from_dict(dict(number='200102034567', application='eduid_oidc_proofing', verified=False))
+        nin_pe = NinProofingElement.from_dict(
+            dict(number='200102034567', application='eduid_oidc_proofing', verified=False)
+        )
         state = OidcProofingState(
             eppn=EPPN,
             state='2c84fedd-a694-46f0-b235-7c4dd7982852',

--- a/src/eduid_userdb/tests/test_proofing.py
+++ b/src/eduid_userdb/tests/test_proofing.py
@@ -59,8 +59,8 @@ class ProofingStateTest(TestCase):
         """
         state = LetterProofingState(
             eppn=EPPN,
-            nin=NinProofingElement(
-                data={
+            nin=NinProofingElement.from_dict(
+                {
                     'number': '200102034567',
                     'created_by': 'eduid_letter_proofing',
                     'created_ts': True,
@@ -72,7 +72,7 @@ class ProofingStateTest(TestCase):
             ),
             id=None,
             modified_ts=None,
-            proofing_letter=SentLetterElement(data={}),
+            proofing_letter=SentLetterElement.from_dict({}),
         )
         state.proofing_letter.address = ADDRESS
         x = state.proofing_letter.to_dict()
@@ -97,7 +97,7 @@ class ProofingStateTest(TestCase):
         }
         """
 
-        nin_pe = NinProofingElement(number='200102034567', application='eduid_oidc_proofing', verified=False)
+        nin_pe = NinProofingElement.from_dict(dict(number='200102034567', application='eduid_oidc_proofing', verified=False))
         state = OidcProofingState(
             eppn=EPPN,
             state='2c84fedd-a694-46f0-b235-7c4dd7982852',

--- a/src/eduid_userdb/tests/test_tou.py
+++ b/src/eduid_userdb/tests/test_tou.py
@@ -98,18 +98,14 @@ class TestToUEvent(TestCase):
         Test that ToUEvent require created_ts, although Event does not.
         """
         with self.assertRaises(eduid_userdb.exceptions.BadEvent):
-            ToUEvent.from_dict(
-                dict(created_by='unit test', created_ts=None, version='foo', event_id=bson.ObjectId())
-            )
+            ToUEvent.from_dict(dict(created_by='unit test', created_ts=None, version='foo', event_id=bson.ObjectId()))
 
     def test_created_ts_is_required2(self):
         """
         Test bad 'version'.
         """
         with self.assertRaises(eduid_userdb.exceptions.BadEvent):
-            ToUEvent.from_dict(
-                dict(created_by='unit test', created_ts=True, version=False, event_id=bson.ObjectId())
-            )
+            ToUEvent.from_dict(dict(created_by='unit test', created_ts=True, version=False, event_id=bson.ObjectId()))
 
     def test_modify_created_ts(self):
         this = self.three.to_list()[-1]

--- a/src/eduid_userdb/tests/test_tou.py
+++ b/src/eduid_userdb/tests/test_tou.py
@@ -76,18 +76,18 @@ class TestToUEvent(TestCase):
         one = copy.deepcopy(_one_dict)
         one['foo'] = 'bar'
         with self.assertRaises(eduid_userdb.exceptions.EventHasUnknownData):
-            ToUEvent(data=one)
+            ToUEvent.from_dict(one)
 
     def test_unknown_input_data_allowed(self):
         one = copy.deepcopy(_one_dict)
         one['foo'] = 'bar'
-        addr = ToUEvent(data=one, raise_on_unknown=False)
+        addr = ToUEvent.from_dict(one, raise_on_unknown=False)
         out = addr.to_dict()
         self.assertIn('foo', out)
         self.assertEqual(out['foo'], one['foo'])
 
     def test_created_by(self):
-        this = Event(application=None, event_id=bson.ObjectId(), event_type='test_event')
+        this = Event.from_dict(dict(created_by=None, event_id=bson.ObjectId(), event_type='test_event'))
         this.created_by = 'unit test'
         self.assertEqual(this.created_by, 'unit test')
         with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
@@ -98,8 +98,8 @@ class TestToUEvent(TestCase):
         Test that ToUEvent require created_ts, although Event does not.
         """
         with self.assertRaises(eduid_userdb.exceptions.BadEvent):
-            ToUEvent(
-                application='unit test', created_ts=None, version='foo', event_id=bson.ObjectId(),
+            ToUEvent.from_dict(
+                dict(created_by='unit test', created_ts=None, version='foo', event_id=bson.ObjectId())
             )
 
     def test_created_ts_is_required2(self):
@@ -107,8 +107,8 @@ class TestToUEvent(TestCase):
         Test bad 'version'.
         """
         with self.assertRaises(eduid_userdb.exceptions.BadEvent):
-            ToUEvent(
-                application='unit test', created_ts=True, version=False, event_id=bson.ObjectId(),
+            ToUEvent.from_dict(
+                dict(created_by='unit test', created_ts=True, version=False, event_id=bson.ObjectId())
             )
 
     def test_modify_created_ts(self):
@@ -146,7 +146,7 @@ EPPN = 'hubba-bubba'
 class TestTouUser(TestCase):
     def test_proper_user(self):
         one = copy.deepcopy(_one_dict)
-        tou = ToUEvent(data=one, raise_on_unknown=False)
+        tou = ToUEvent.from_dict(one, raise_on_unknown=False)
         userdata = new_user_example.to_dict()
         userdata['tou'] = [tou]
         user = ToUUser.from_dict(data=userdata)
@@ -154,7 +154,7 @@ class TestTouUser(TestCase):
 
     def test_proper_new_user(self):
         one = copy.deepcopy(_one_dict)
-        tou = ToUList([ToUEvent(data=one, raise_on_unknown=False)])
+        tou = ToUList([ToUEvent.from_dict(one, raise_on_unknown=False)])
         userdata = new_user_example.to_dict()
         userid = userdata.pop('_id')
         eppn = userdata.pop('eduPersonPrincipalName')
@@ -164,7 +164,7 @@ class TestTouUser(TestCase):
 
     def test_proper_new_user_no_id(self):
         one = copy.deepcopy(_one_dict)
-        tou = ToUList([ToUEvent(data=one, raise_on_unknown=False)])
+        tou = ToUList([ToUEvent.from_dict(one, raise_on_unknown=False)])
         userdata = new_user_example.to_dict()
         passwords = CredentialList(userdata['passwords'])
         with self.assertRaises(UserMissingData):
@@ -172,7 +172,7 @@ class TestTouUser(TestCase):
 
     def test_proper_new_user_no_eppn(self):
         one = copy.deepcopy(_one_dict)
-        tou = ToUList([ToUEvent(data=one, raise_on_unknown=False)])
+        tou = ToUList([ToUEvent.from_dict(one, raise_on_unknown=False)])
         userdata = new_user_example.to_dict()
         userid = userdata.pop('_id')
         passwords = CredentialList(userdata['passwords'])
@@ -189,13 +189,13 @@ class TestTouUser(TestCase):
 
     def test_missing_eppn(self):
         one = copy.deepcopy(_one_dict)
-        tou = ToUList([ToUEvent(data=one, raise_on_unknown=False)])
+        tou = ToUList([ToUEvent.from_dict(one, raise_on_unknown=False)])
         with self.assertRaises(UserMissingData):
             ToUUser.from_dict(data=dict(tou=tou, userid=USERID))
 
     def test_missing_userid(self):
         one = copy.deepcopy(_one_dict)
-        tou = ToUEvent(data=one, raise_on_unknown=False)
+        tou = ToUEvent.from_dict(one, raise_on_unknown=False)
         with self.assertRaises(UserMissingData):
             ToUUser.from_dict(data=dict(tou=[tou], eppn=EPPN))
 
@@ -205,7 +205,7 @@ class TestTouUser(TestCase):
 
     def test_unknown_data(self):
         one = copy.deepcopy(_one_dict)
-        tou = ToUEvent(data=one, raise_on_unknown=False)
+        tou = ToUEvent.from_dict(one, raise_on_unknown=False)
         userdata = new_user_example.to_dict()
         userdata['tou'] = [tou]
         userdata['foo'] = 'bar'
@@ -214,7 +214,7 @@ class TestTouUser(TestCase):
 
     def test_unknown_data_dont_raise(self):
         one = copy.deepcopy(_one_dict)
-        tou = ToUEvent(data=one, raise_on_unknown=False)
+        tou = ToUEvent.from_dict(one, raise_on_unknown=False)
         userdata = new_user_example.to_dict()
         userdata['tou'] = [tou]
         userdata['foo'] = 'bar'

--- a/src/eduid_userdb/tests/test_u2f.py
+++ b/src/eduid_userdb/tests/test_u2f.py
@@ -71,12 +71,12 @@ class TestU2F(TestCase):
         one = copy.deepcopy(_one_dict)
         one['foo'] = 'bar'
         with self.assertRaises(eduid_userdb.exceptions.UserHasUnknownData):
-            U2F(data=one)
+            U2F.from_dict(one)
 
     def test_unknown_input_data_allowed(self):
         one = copy.deepcopy(_one_dict)
         one['foo'] = 'bar'
-        addr = U2F(data=one, raise_on_unknown=False)
+        addr = U2F.from_dict(one, raise_on_unknown=False)
         out = addr.to_dict()
         self.assertIn('foo', out)
         self.assertEqual(out['foo'], one['foo'])

--- a/src/eduid_userdb/tests/test_user.py
+++ b/src/eduid_userdb/tests/test_user.py
@@ -814,7 +814,7 @@ class TestNewUser(TestCase, _AbstractUserTestCase):
                 'a_map': {'some': 'data'},
             },
         }
-        profile = Profile.from_dict(profile_dict)
+        profile = Profile(**profile_dict)
         profile_list = [profile]
         profiles = ProfileList(profile_list)
         language = 'sv'

--- a/src/eduid_userdb/tests/test_user.py
+++ b/src/eduid_userdb/tests/test_user.py
@@ -418,8 +418,8 @@ class _AbstractUserTestCase:
     def test_locked_identity_set(self):
         locked_identity = {'created_by': 'test', 'created_ts': True, 'identity_type': 'nin', 'number': '197801012345'}
         user = User.from_dict(self.data1)
-        locked_nin = LockedIdentityNin(
-            locked_identity['number'], locked_identity['created_by'], locked_identity['created_ts']
+        locked_nin = LockedIdentityNin.from_dict(
+            dict(number=locked_identity['number'], created_by=locked_identity['created_by'], created_ts=locked_identity['created_ts'])
         )
         user.locked_identity.add(locked_nin)
         self.assertEqual(user.locked_identity.count, 1)
@@ -433,8 +433,8 @@ class _AbstractUserTestCase:
     def test_locked_identity_to_dict(self):
         locked_identity = {'created_by': 'test', 'created_ts': True, 'identity_type': 'nin', 'number': '197801012345'}
         user = User.from_dict(self.data1)
-        locked_nin = LockedIdentityNin(
-            locked_identity['number'], locked_identity['created_by'], locked_identity['created_ts']
+        locked_nin = LockedIdentityNin.from_dict(
+            dict(number=locked_identity['number'], created_by=locked_identity['created_by'], created_ts=locked_identity['created_ts'])
         )
         user.locked_identity.add(locked_nin)
 
@@ -455,8 +455,8 @@ class _AbstractUserTestCase:
     def test_locked_identity_remove(self):
         locked_identity = {'created_by': 'test', 'created_ts': True, 'identity_type': 'nin', 'number': '197801012345'}
         user = User.from_dict(self.data1)
-        locked_nin = LockedIdentityNin(
-            locked_identity['number'], locked_identity['created_by'], locked_identity['created_ts']
+        locked_nin = LockedIdentityNin.from_dict(
+            dict(number=locked_identity['number'], created_by=locked_identity['created_by'], created_ts=locked_identity['created_ts'])
         )
         user.locked_identity.add(locked_nin)
         with self.assertRaises(EduIDUserDBError):
@@ -479,9 +479,12 @@ class _AbstractUserTestCase:
             "token_type": "bearer",
         }
         orcid = "user_orcid"
-        oidc_id_token = OidcIdToken(application='test', **id_token)
-        oidc_authz = OidcAuthorization(id_token=oidc_id_token, application='test', **oidc_data)
-        orcid_element = Orcid(id=orcid, oidc_authz=oidc_authz, application='test')
+        id_token['created_by'] = 'test'
+        oidc_id_token = OidcIdToken.from_dict(id_token)
+        oidc_data['created_by'] = 'test'
+        oidc_data['id_token'] = oidc_id_token
+        oidc_authz = OidcAuthorization.from_dict(oidc_data)
+        orcid_element = Orcid.from_dict(dict(id=orcid, oidc_authz=oidc_authz, created_by='test'))
 
         user = User.from_dict(self.data1)
         user.orcid = orcid_element
@@ -799,7 +802,7 @@ class TestNewUser(TestCase, _AbstractUserTestCase):
                 'a_map': {'some': 'data'},
             },
         }
-        profile = Profile(**profile_dict)
+        profile = Profile.from_dict(profile_dict)
         profile_list = [profile]
         profiles = ProfileList(profile_list)
         language = 'sv'

--- a/src/eduid_userdb/tests/test_user.py
+++ b/src/eduid_userdb/tests/test_user.py
@@ -419,7 +419,11 @@ class _AbstractUserTestCase:
         locked_identity = {'created_by': 'test', 'created_ts': True, 'identity_type': 'nin', 'number': '197801012345'}
         user = User.from_dict(self.data1)
         locked_nin = LockedIdentityNin.from_dict(
-            dict(number=locked_identity['number'], created_by=locked_identity['created_by'], created_ts=locked_identity['created_ts'])
+            dict(
+                number=locked_identity['number'],
+                created_by=locked_identity['created_by'],
+                created_ts=locked_identity['created_ts'],
+            )
         )
         user.locked_identity.add(locked_nin)
         self.assertEqual(user.locked_identity.count, 1)
@@ -434,7 +438,11 @@ class _AbstractUserTestCase:
         locked_identity = {'created_by': 'test', 'created_ts': True, 'identity_type': 'nin', 'number': '197801012345'}
         user = User.from_dict(self.data1)
         locked_nin = LockedIdentityNin.from_dict(
-            dict(number=locked_identity['number'], created_by=locked_identity['created_by'], created_ts=locked_identity['created_ts'])
+            dict(
+                number=locked_identity['number'],
+                created_by=locked_identity['created_by'],
+                created_ts=locked_identity['created_ts'],
+            )
         )
         user.locked_identity.add(locked_nin)
 
@@ -456,7 +464,11 @@ class _AbstractUserTestCase:
         locked_identity = {'created_by': 'test', 'created_ts': True, 'identity_type': 'nin', 'number': '197801012345'}
         user = User.from_dict(self.data1)
         locked_nin = LockedIdentityNin.from_dict(
-            dict(number=locked_identity['number'], created_by=locked_identity['created_by'], created_ts=locked_identity['created_ts'])
+            dict(
+                number=locked_identity['number'],
+                created_by=locked_identity['created_by'],
+                created_ts=locked_identity['created_ts'],
+            )
         )
         user.locked_identity.add(locked_nin)
         with self.assertRaises(EduIDUserDBError):

--- a/src/eduid_userdb/tests/test_webauthn.py
+++ b/src/eduid_userdb/tests/test_webauthn.py
@@ -73,12 +73,12 @@ class TestWebauthn(TestCase):
         one = copy.deepcopy(_one_dict)
         one['foo'] = 'bar'
         with self.assertRaises(eduid_userdb.exceptions.UserHasUnknownData):
-            Webauthn(data=one)
+            Webauthn.from_dict(one)
 
     def test_unknown_input_data_allowed(self):
         one = copy.deepcopy(_one_dict)
         one['foo'] = 'bar'
-        addr = Webauthn(data=one, raise_on_unknown=False)
+        addr = Webauthn.from_dict(one, raise_on_unknown=False)
         out = addr.to_dict()
         self.assertIn('foo', out)
         self.assertEqual(out['foo'], one['foo'])

--- a/src/eduid_userdb/tou.py
+++ b/src/eduid_userdb/tou.py
@@ -57,6 +57,7 @@ class ToUEvent(Event):
         event_id=None,
         data: Optional[Dict[str, Any]] = None,
         raise_on_unknown=True,
+        called_directly=True,
     ):
         data_in = data
         data = copy.copy(data_in)  # to not modify callers data
@@ -73,7 +74,7 @@ class ToUEvent(Event):
         for required in ['created_by', 'created_ts']:
             if required not in data or not data.get(required):
                 raise BadEvent('missing required data for event: {!s}'.format(required))
-        Event.__init__(self, data=data, raise_on_unknown=raise_on_unknown, ignore_data=['version'])
+        Event.__init__(self, data=data, raise_on_unknown=raise_on_unknown, called_directly=called_directly, ignore_data=['version'])
         self.version = data.pop('version')
 
     # -----------------------------------------------------------------

--- a/src/eduid_userdb/tou.py
+++ b/src/eduid_userdb/tou.py
@@ -35,11 +35,10 @@
 
 import copy
 import datetime
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Dict, List, Optional
 
 from six import string_types
 
-from eduid_userdb.element import TElementSubclass
 from eduid_userdb.event import Event, EventList
 from eduid_userdb.exceptions import BadEvent, EduIDUserDBError, UserDBValueError
 

--- a/src/eduid_userdb/tou.py
+++ b/src/eduid_userdb/tou.py
@@ -75,7 +75,9 @@ class ToUEvent(Event):
         for required in ['created_by', 'created_ts']:
             if required not in data or not data.get(required):
                 raise BadEvent('missing required data for event: {!s}'.format(required))
-        Event.__init__(self, data=data, raise_on_unknown=raise_on_unknown, called_directly=called_directly, ignore_data=['version'])
+        Event.__init__(
+            self, data=data, raise_on_unknown=raise_on_unknown, called_directly=called_directly, ignore_data=['version']
+        )
         self.version = data.pop('version')
 
     @classmethod

--- a/src/eduid_userdb/tou.py
+++ b/src/eduid_userdb/tou.py
@@ -80,13 +80,6 @@ class ToUEvent(Event):
         )
         self.version = data.pop('version')
 
-    @classmethod
-    def from_dict(cls: Type[TElementSubclass], data: Dict[str, Any], raise_on_unknown: bool = True) -> TElementSubclass:
-        """
-        Construct user from a data dict.
-        """
-        return cls(data=data, raise_on_unknown=raise_on_unknown, called_directly=False)
-
     # -----------------------------------------------------------------
     @property
     def version(self):

--- a/src/eduid_userdb/tou.py
+++ b/src/eduid_userdb/tou.py
@@ -35,7 +35,7 @@
 
 import copy
 import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from six import string_types
 
@@ -50,14 +50,14 @@ class ToUEvent(Event):
 
     def __init__(
         self,
-        version=None,
-        application=None,
-        created_ts=None,
-        modified_ts=None,
-        event_id=None,
+        version: Optional[str] = None,
+        application: Optional[str] = None,
+        created_ts: Optional[Union[datetime.datetime, bool]] = None,
+        modified_ts: Optional[Union[datetime.datetime, bool]] = None,
+        event_id: Optional[str] = None,
         data: Optional[Dict[str, Any]] = None,
-        raise_on_unknown=True,
-        called_directly=True,
+        raise_on_unknown: bool = True,
+        called_directly: bool = True,
     ):
         data_in = data
         data = copy.copy(data_in)  # to not modify callers data

--- a/src/eduid_userdb/tou.py
+++ b/src/eduid_userdb/tou.py
@@ -35,10 +35,11 @@
 
 import copy
 import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Type
 
 from six import string_types
 
+from eduid_userdb.element import TElementSubclass
 from eduid_userdb.event import Event, EventList
 from eduid_userdb.exceptions import BadEvent, EduIDUserDBError, UserDBValueError
 
@@ -76,6 +77,13 @@ class ToUEvent(Event):
                 raise BadEvent('missing required data for event: {!s}'.format(required))
         Event.__init__(self, data=data, raise_on_unknown=raise_on_unknown, called_directly=called_directly, ignore_data=['version'])
         self.version = data.pop('version')
+
+    @classmethod
+    def from_dict(cls: Type[TElementSubclass], data: Dict[str, Any], raise_on_unknown: bool = True) -> TElementSubclass:
+        """
+        Construct user from a data dict.
+        """
+        return cls(data=data, raise_on_unknown=raise_on_unknown, called_directly=False)
 
     # -----------------------------------------------------------------
     @property

--- a/src/eduid_userdb/user.py
+++ b/src/eduid_userdb/user.py
@@ -366,7 +366,7 @@ class User(object):
         self._orcid = None
         _orcid = self._data_in.pop('orcid', None)
         if _orcid is not None:
-            self._orcid = Orcid(data=_orcid)
+            self._orcid = Orcid.from_dict(_orcid)
 
     def _parse_profiles(self):
         """


### PR DESCRIPTION
This introduces the `from_dict` classmethod into `Element` and subclasses, as a replacement for the deprecated direct calls to `__init__`.

There are a couple of complications. One is that not all subclasses of Element accept a data dict in the constructor; some just accept keyword args and thus are very near a dataclass. So I have not deprecated those. Those are the log elements, the Profile, and the code elements.

Another complication is the `raise_on_unknown` parameter. Neither Element nor VerifiedElement accept raise_on_unknown, and PrimaryElement does. However, there are subclasses of Element and VerifiedElement that do accept it. Since this parameter must also be provided to `from_dict`, these classes cannot inherit the `from_dict` from their parent classes (mypy complains), and must implement their own. I considered here adding a RaisingElement and RaisingVerifiedElement classes accepting raise_on_unknown in their `__init__` and from_dict, but that would mean divergent mro's  for the `from_dict` method and for the "keyword args signature", that I think would complicate the road towards dataclasses. So there are quite a few implementations of `from_dict` that accept raise_on_unknown, differering in their `cls` and return types.

The locked identity elements are a special case. There is a LockedIdentityElement whose `__init__` accepts a data dict, and a subclass LockeddIdentityNin that does not. In this case I have added a new data dict arg to LockedIdentityNin, to move it forward with the rest of elements.