### PR TITLE
Eperez elem init 4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ README = 'eduID User Database interface module'
 if os.path.exists(README_fn):
     README = open(README_fn).read()
 
-version = '0.4.18'
+version = '0.5.0'
 
 install_requires = [
     'pymongo >= 3.6',

--- a/src/eduid_userdb/credentials/base.py
+++ b/src/eduid_userdb/credentials/base.py
@@ -78,11 +78,11 @@ class Credential(VerifiedElement):
 
         return self.key == other.key
 
-    def data_out_transforms(self, data: Dict[str, Any]) -> Dict[str, Any]:
+    def _data_out_transforms(self, data: Dict[str, Any], old_userdb_format: bool = False) -> Dict[str, Any]:
         """
         Make sure we never store proofing info for un-verified credentials
         """
-        data = super().data_out_transforms(data)
+        data = super()._data_out_transforms(data, old_userdb_format)
 
         if data.get('verified') is False:
             del data['verified']

--- a/src/eduid_userdb/credentials/base.py
+++ b/src/eduid_userdb/credentials/base.py
@@ -69,11 +69,11 @@ class Credential(VerifiedElement):
         else:
             return '<eduID {!s}(key=\'{!s}...\'): verified=False>'.format(self.__class__.__name__, shortkey)
 
-    def _data_out_transforms(self, data: Dict[str, Any], old_userdb_format: bool = False) -> Dict[str, Any]:
+    def _data_out_transforms(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Make sure we never store proofing info for un-verified credentials
         """
-        data = super()._data_out_transforms(data, old_userdb_format)
+        data = super()._data_out_transforms(data)
 
         if data.get('verified') is False:
             del data['verified']

--- a/src/eduid_userdb/credentials/base.py
+++ b/src/eduid_userdb/credentials/base.py
@@ -69,15 +69,6 @@ class Credential(VerifiedElement):
         else:
             return '<eduID {!s}(key=\'{!s}...\'): verified=False>'.format(self.__class__.__name__, shortkey)
 
-    def __hash__(self):
-        return hash(self.key)
-
-    def __eq__(self, other):
-        if not isinstance(other, type(self)):
-            return False
-
-        return self.key == other.key
-
     def _data_out_transforms(self, data: Dict[str, Any], old_userdb_format: bool = False) -> Dict[str, Any]:
         """
         Make sure we never store proofing info for un-verified credentials

--- a/src/eduid_userdb/credentials/base.py
+++ b/src/eduid_userdb/credentials/base.py
@@ -68,7 +68,7 @@ class Credential(VerifiedElement):
     def data_out_transforms(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """
         """
-        data = super().data_in_transforms(data)
+        data = super().data_out_transforms(data)
 
         if data.get('verified') is True:
             # suppress method/version None to avoid messing up test cases unnecessarily

--- a/src/eduid_userdb/credentials/base.py
+++ b/src/eduid_userdb/credentials/base.py
@@ -72,6 +72,9 @@ class Credential(VerifiedElement):
         return hash(self.key)
 
     def __eq__(self, other):
+        if not isinstance(other, type(self)):
+            return False
+
         return self.key == other.key
 
     def data_out_transforms(self, data: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/eduid_userdb/credentials/base.py
+++ b/src/eduid_userdb/credentials/base.py
@@ -65,6 +65,12 @@ class Credential(VerifiedElement):
         else:
             return '<eduID {!s}(key=\'{!s}...\'): verified=False>'.format(self.__class__.__name__, shortkey)
 
+    def __hash__(self):
+        return hash(str(self.key))
+
+    def __eq__(self, other):
+        return self.key == other.key
+
     def data_out_transforms(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """
         """

--- a/src/eduid_userdb/credentials/base.py
+++ b/src/eduid_userdb/credentials/base.py
@@ -69,11 +69,11 @@ class Credential(VerifiedElement):
         else:
             return '<eduID {!s}(key=\'{!s}...\'): verified=False>'.format(self.__class__.__name__, shortkey)
 
-    def _data_out_transforms(self, data: Dict[str, Any]) -> Dict[str, Any]:
+    def _to_dict_transform(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Make sure we never store proofing info for un-verified credentials
         """
-        data = super()._data_out_transforms(data)
+        data = super()._to_dict_transform(data)
 
         if data.get('verified') is False:
             del data['verified']

--- a/src/eduid_userdb/credentials/base.py
+++ b/src/eduid_userdb/credentials/base.py
@@ -56,6 +56,7 @@ class Credential(VerifiedElement):
     There is some use of these objects as keys in dicts in eduid-IdP,
     so we are making them hashable.
     """
+
     proofing_method: Optional[str] = None
     proofing_version: Optional[str] = None
 

--- a/src/eduid_userdb/credentials/base.py
+++ b/src/eduid_userdb/credentials/base.py
@@ -36,7 +36,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, ClassVar, Dict, Optional
+from typing import Any, Dict, Optional
 
 from eduid_userdb.element import VerifiedElement
 

--- a/src/eduid_userdb/credentials/base.py
+++ b/src/eduid_userdb/credentials/base.py
@@ -36,7 +36,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, ClassVar, Dict, Optional
 
 from eduid_userdb.element import VerifiedElement
 
@@ -65,19 +65,22 @@ class Credential(VerifiedElement):
         else:
             return '<eduID {!s}(key=\'{!s}...\'): verified=False>'.format(self.__class__.__name__, shortkey)
 
-    def to_dict(self, old_userdb_format=False):
-        res = super(Credential, self).to_dict(old_userdb_format=old_userdb_format)
-        if res.get('verified') is True:
+    def data_out_transforms(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        """
+        data = super().data_in_transforms(data)
+
+        if data.get('verified') is True:
             # suppress method/version None to avoid messing up test cases unnecessarily
-            if 'proofing_method' in res and res['proofing_method'] is None:
-                del res['proofing_method']
-            if 'proofing_version' in res and res['proofing_version'] is None:
-                del res['proofing_version']
-        elif res.get('verified') is False:
-            del res['verified']
+            if 'proofing_method' in data and data['proofing_method'] is None:
+                del data['proofing_method']
+            if 'proofing_version' in data and data['proofing_version'] is None:
+                del data['proofing_version']
+        elif data.get('verified') is False:
+            del data['verified']
             # Make sure we never store proofing info for un-verified credentials
-            if 'proofing_method' in res:
-                del res['proofing_method']
-            if 'proofing_version' in res:
-                del res['proofing_version']
-        return res
+            if 'proofing_method' in data:
+                del data['proofing_method']
+            if 'proofing_version' in data:
+                del data['proofing_version']
+        return data

--- a/src/eduid_userdb/credentials/base.py
+++ b/src/eduid_userdb/credentials/base.py
@@ -36,12 +36,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, Type
-
-from six import string_types
+from typing import Optional
 
 from eduid_userdb.element import VerifiedElement
-from eduid_userdb.exceptions import UserDBValueError
 
 __author__ = 'ft'
 

--- a/src/eduid_userdb/credentials/base.py
+++ b/src/eduid_userdb/credentials/base.py
@@ -35,7 +35,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Type
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Type
 
 from six import string_types
 
@@ -45,6 +46,7 @@ from eduid_userdb.exceptions import UserDBValueError
 __author__ = 'ft'
 
 
+@dataclass
 class Credential(VerifiedElement):
     """
     Base class for credentials.
@@ -54,23 +56,8 @@ class Credential(VerifiedElement):
     only for credentials until we know we want it for other types of verifed
     elements too.
     """
-
-    def __init__(self, data: Dict[str, Any], called_directly: bool = True):
-        raise NotImplementedError()
-
-    @classmethod
-    def from_dict(
-        cls: Type[Credential], data: Dict[str, Any]
-    ) -> Credential:
-        """
-        Construct credential from a data dict.
-        """
-        self = super().from_dict(data)
-
-        self.proofing_method = data.pop('proofing_method', None)
-        self.proofing_version = data.pop('proofing_version', None)
-
-        return self
+    proofing_method: Optional[str] = None
+    proofing_version: Optional[str] = None
 
     def __str__(self):
         shortkey = self.key[:12]
@@ -80,44 +67,6 @@ class Credential(VerifiedElement):
             )
         else:
             return '<eduID {!s}(key=\'{!s}...\'): verified=False>'.format(self.__class__.__name__, shortkey)
-
-    # -----------------------------------------------------------------
-    @property
-    def proofing_method(self):
-        """
-        :return: Name of proofing process used to verify this credential.
-        :rtype: string_types | None
-        """
-        return self._data['proofing_method']
-
-    @proofing_method.setter
-    def proofing_method(self, value):
-        """
-        :param value: Name of proofing process used
-        :type value: string_types | None
-        """
-        if not isinstance(value, string_types) and value is not None:
-            raise UserDBValueError("Invalid 'proofing_method': {!r}".format(value))
-        self._data['proofing_method'] = value
-
-    # -----------------------------------------------------------------
-    @property
-    def proofing_version(self):
-        """
-        :return: Name of proofing process used to verify this credential.
-        :rtype: string_types | None
-        """
-        return self._data['proofing_version']
-
-    @proofing_version.setter
-    def proofing_version(self, value):
-        """
-        :param value: Name of proofing process used
-        :type value: string_types | None
-        """
-        if not isinstance(value, string_types) and value is not None:
-            raise UserDBValueError("Invalid 'proofing_version': {!r}".format(value))
-        self._data['proofing_version'] = value
 
     def to_dict(self, old_userdb_format=False):
         res = super(Credential, self).to_dict(old_userdb_format=old_userdb_format)

--- a/src/eduid_userdb/credentials/fido.py
+++ b/src/eduid_userdb/credentials/fido.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from hashlib import sha256
-from typing import ClassVar, Dict, Optional
+from typing import Any, ClassVar, Dict, Optional
 
 from eduid_userdb.credentials import Credential
 
@@ -53,7 +53,7 @@ class _FidoCredentialRequired:
     app_id: str
 
 
-@dataclass(eq=True, unsafe_hash=True)
+@dataclass(eq=False, unsafe_hash=True)
 class FidoCredential(Credential, _FidoCredentialRequired):
     """
     Token authentication credential
@@ -71,7 +71,7 @@ class _U2FCredentialRequired:
     public_key: str
 
 
-@dataclass(eq=True, unsafe_hash=True)
+@dataclass(eq=False, unsafe_hash=True)
 class U2F(FidoCredential, _U2FCredentialRequired):
     """
     U2F token authentication credential
@@ -81,28 +81,25 @@ class U2F(FidoCredential, _U2FCredentialRequired):
     name_mapping: ClassVar[Dict[str, str]] = {'application': 'created_by'}
 
     @property
-    def key(self):
+    def key(self) -> str:
         """
         Return the element that is used as key.
         """
         return 'sha256:' + sha256(self.keyhandle.encode('utf-8') + self.public_key.encode('utf-8')).hexdigest()
 
 
-def u2f_from_dict(data, raise_on_unknown=True):
+def u2f_from_dict(data: Dict[str, Any], raise_on_unknown: bool = True) -> U2F:
     """
     Create an U2F instance from a dict.
 
     :param data: Credential parameters from database
     :param raise_on_unknown: Raise UserHasUnknownData if unrecognized data is encountered
-
-    :type data: dict
-    :type raise_on_unknown: bool
-    :rtype: U2F
+                             kept for B/C
     """
     return U2F.from_dict(data)
 
 
-@dataclass(eq=True, unsafe_hash=True)
+@dataclass(eq=False, unsafe_hash=True)
 class Webauthn(FidoCredential):
     """
     Webauthn token authentication credential
@@ -113,22 +110,19 @@ class Webauthn(FidoCredential):
     name_mapping: ClassVar[Dict[str, str]] = {'application': 'created_by'}
 
     @property
-    def key(self):
+    def key(self) -> str:
         """
         Return the element that is used as key.
         """
         return 'sha256:' + sha256(self.keyhandle.encode('utf-8') + self.credential_data.encode('utf-8')).hexdigest()
 
 
-def webauthn_from_dict(data, raise_on_unknown=True):
+def webauthn_from_dict(data: Dict[str, Any], raise_on_unknown: bool = True) -> Webauthn:
     """
     Create an Webauthn instance from a dict.
 
     :param data: Credential parameters from database
     :param raise_on_unknown: Raise UserHasUnknownData if unrecognized data is encountered
-
-    :type data: dict
-    :type raise_on_unknown: bool
-    :rtype: Webauthn
+                             kept for B/C
     """
     return Webauthn.from_dict(data)

--- a/src/eduid_userdb/credentials/fido.py
+++ b/src/eduid_userdb/credentials/fido.py
@@ -53,7 +53,7 @@ class _FidoCredentialRequired:
     app_id: str
 
 
-@dataclass
+@dataclass(eq=True, unsafe_hash=True)
 class FidoCredential(Credential, _FidoCredentialRequired):
     """
     Token authentication credential
@@ -71,7 +71,7 @@ class _U2FCredentialRequired:
     public_key: str
 
 
-@dataclass
+@dataclass(eq=True, unsafe_hash=True)
 class U2F(FidoCredential, _U2FCredentialRequired):
     """
     U2F token authentication credential
@@ -102,7 +102,7 @@ def u2f_from_dict(data, raise_on_unknown=True):
     return U2F.from_dict(data)
 
 
-@dataclass
+@dataclass(eq=True, unsafe_hash=True)
 class Webauthn(FidoCredential):
     """
     Webauthn token authentication credential

--- a/src/eduid_userdb/credentials/fido.py
+++ b/src/eduid_userdb/credentials/fido.py
@@ -62,17 +62,6 @@ class FidoCredential(Credential, _FidoCredentialRequired):
 
     description: str = ''
 
-    def _data_out_transforms(self, data: Dict[str, Any], old_userdb_format: bool = False) -> Dict[str, Any]:
-        """
-        Transform data kept in pythonic format into eduid format.
-        """
-        if 'created_by' in data:
-            data['application'] = data.pop('created_by')
-
-        data = super()._data_out_transforms(data, old_userdb_format)
-
-        return data
-
 
 @dataclass
 class _U2FCredentialRequired:

--- a/src/eduid_userdb/credentials/fido.py
+++ b/src/eduid_userdb/credentials/fido.py
@@ -54,7 +54,7 @@ class _FidoCredentialRequired:
     app_id: str
 
 
-@dataclass(eq=False, unsafe_hash=True)
+@dataclass
 class FidoCredential(Credential, _FidoCredentialRequired):
     """
     Token authentication credential
@@ -85,7 +85,7 @@ class _U2FCredentialRequired:
     public_key: str
 
 
-@dataclass(eq=False, unsafe_hash=True)
+@dataclass
 class U2F(FidoCredential, _U2FCredentialRequired):
     """
     U2F token authentication credential
@@ -112,7 +112,7 @@ def u2f_from_dict(data: Dict[str, Any], raise_on_unknown: bool = True) -> U2F:
     return U2F.from_dict(data)
 
 
-@dataclass(eq=False, unsafe_hash=True)
+@dataclass
 class Webauthn(FidoCredential):
     """
     Webauthn token authentication credential

--- a/src/eduid_userdb/credentials/fido.py
+++ b/src/eduid_userdb/credentials/fido.py
@@ -44,7 +44,7 @@ __author__ = 'ft'
 
 
 @dataclass
-class _FidoCredentialRequired(Credential):
+class _FidoCredentialRequired:
     """
     Required fields for FidoCredential, so that they go before the optional
     arguments of Element in the implicit constructor.
@@ -62,7 +62,7 @@ class FidoCredential(Credential, _FidoCredentialRequired):
 
 
 @dataclass
-class _U2FCredentialRequired(Credential):
+class _U2FCredentialRequired:
     """
     Required fields for U2F, so that they go before the optional
     arguments in the implicit constructor.

--- a/src/eduid_userdb/credentials/fido.py
+++ b/src/eduid_userdb/credentials/fido.py
@@ -34,157 +34,49 @@
 #
 from __future__ import annotations
 
-import copy
-from datetime import datetime
+from dataclasses import dataclass
 from hashlib import sha256
-from typing import Any, Dict, Optional, Type, Union
-
-from six import string_types
+from typing import Optional
 
 from eduid_userdb.credentials import Credential
-from eduid_userdb.exceptions import UserDBValueError, UserHasUnknownData
 
 __author__ = 'ft'
 
 
-class FidoCredential(Credential):
+@dataclass
+class _FidoCredentialRequired(Credential):
+    """
+    Required fields for FidoCredential, so that they go before the optional
+    arguments of Element in the implicit constructor.
+    """
+    keyhandle: str
+    app_id: str
+
+
+@dataclass
+class FidoCredential(Credential, _FidoCredentialRequired):
     """
     Token authentication credential
     """
-
-    def __init__(self, data: Dict[str, Any], called_directly: bool = True):
-        raise NotImplementedError()
-
-    @classmethod
-    def from_dict(
-        cls: Type[FidoCredential], data: Dict[str, Any]
-    ) -> FidoCredential:
-        """
-        Construct fido credential from a data dict.
-        """
-        self = super().from_dict(data)
-        self.keyhandle = data.pop('keyhandle')
-        self.app_id = data.pop('app_id')
-        self.description = data.pop('description', '')
-
-        return self
-
-    def check_unknown_data(self, data: Dict[str, Any]):
-        """
-        called when an instance of a subclass is created with `raise_on_unknown`
-        """
-        leftovers = data.keys()
-        if leftovers:
-            raise UserHasUnknownData(f'{self.__class__.__name__} {self.key} unknown data: {leftovers}')
-
-    @property
-    def keyhandle(self):
-        """
-        This is the server side reference to the U2F token used.
-
-        :return: U2F keyhandle.
-        :rtype: str
-        """
-        return self._data['keyhandle']
-
-    @keyhandle.setter
-    def keyhandle(self, value):
-        """
-        :param value: U2F keyhandle.
-        :type value: str
-        """
-        if not isinstance(value, string_types):
-            raise UserDBValueError("Invalid 'keyhandle': {!r}".format(value))
-        self._data['keyhandle'] = value
-
-    @property
-    def app_id(self):
-        """
-        The U2F app_id used when creating this credential.
-
-        :return: U2F app_id
-        :rtype: str
-        """
-        return self._data['app_id']
-
-    @app_id.setter
-    def app_id(self, value):
-        """
-        :param value: U2F app_id.
-        :type value: str
-        """
-        if not isinstance(value, string_types):
-            raise UserDBValueError("Invalid 'app_id': {!r}".format(value))
-        self._data['app_id'] = value
-
-    @property
-    def description(self):
-        """
-        User description/name of this token.
-
-        :return: description
-        :rtype: str
-        """
-        return self._data['description']
-
-    @description.setter
-    def description(self, value):
-        """
-        :param value: U2F description.
-        :type value: str
-        """
-        if not isinstance(value, string_types):
-            raise UserDBValueError("Invalid 'description': {!r}".format(value))
-        self._data['description'] = value
+    description: str = ''
 
 
-class U2F(FidoCredential):
+@dataclass
+class _U2FCredentialRequired(Credential):
+    """
+    Required fields for U2F, so that they go before the optional
+    arguments in the implicit constructor.
+    """
+    version: str
+    public_key: str
+
+
+@dataclass
+class U2F(FidoCredential, _U2FCredentialRequired):
     """
     U2F token authentication credential
     """
-
-    def __init__(
-        self,
-        version: Optional[str] = None,
-        keyhandle: Optional[str] = None,
-        public_key: Optional[str] = None,
-        app_id: Optional[str] = None,
-        attest_cert: Optional[str] = None,
-        description: Optional[str] = None,
-        application: Optional[str] = None,
-        created_ts: Optional[Union[datetime, bool]] = None,
-        data: Optional[Dict[str, Any]] = None,
-        raise_on_unknown: bool = True,
-        called_directly: bool = True,
-    ):
-        raise NotImplementedError()
-
-    @classmethod
-    def from_dict(
-        cls: Type[U2F], data: Dict[str, Any], raise_on_unknown: bool = True
-    ) -> U2F:
-        """
-        Construct U2F credential from a data dict.
-        """
-        data_in = data
-        data = copy.copy(data_in)  # to not modify callers data
-
-        if 'created_ts' not in data:
-            data['created_ts'] = True
-
-        self = super().from_dict(data)
-
-        self.version = data.pop('version')
-        self.public_key = data.pop('public_key')
-        self.attest_cert = data.pop('attest_cert', '')
-
-        if raise_on_unknown:
-            self.check_unknown_data(data)
-
-        # Just keep everything that is left as-is
-        self._data.update(data)
-
-        return self
+    attest_cert: Optional[str] = None
 
     @property
     def key(self):
@@ -192,69 +84,6 @@ class U2F(FidoCredential):
         Return the element that is used as key.
         """
         return 'sha256:' + sha256(self.keyhandle.encode('utf-8') + self.public_key.encode('utf-8')).hexdigest()
-
-    @property
-    def version(self):
-        """
-        This is the U2F version used by this token.
-
-        :return: U2F version.
-        :rtype: str
-        """
-        return self._data['version']
-
-    @version.setter
-    def version(self, value):
-        """
-        :param value: U2F version. E.g. 'U2F_V2'.
-        :type value: str
-        """
-        if not isinstance(value, string_types):
-            raise UserDBValueError("Invalid 'version': {!r}".format(value))
-        self._data['version'] = value
-
-    @property
-    def attest_cert(self):
-        """
-        The U2F attest_cert from the credential.
-
-        We should probably refine what we store here later on, but for now we just
-        store the whole certificate.
-
-        :return: U2F attest_cert
-        :rtype: str
-        """
-        return self._data['attest_cert']
-
-    @attest_cert.setter
-    def attest_cert(self, value):
-        """
-        :param value: U2F attest_cert.
-        :type value: str
-        """
-        if not isinstance(value, string_types):
-            raise UserDBValueError("Invalid 'attest_cert': {!r}".format(value))
-        self._data['attest_cert'] = value
-
-    @property
-    def public_key(self):
-        """
-        This is the public key of the U2F token.
-
-        :return: U2F public_key.
-        :rtype: str
-        """
-        return self._data['public_key']
-
-    @public_key.setter
-    def public_key(self, value):
-        """
-        :param value: U2F public_key.
-        :type value: str
-        """
-        if not isinstance(value, string_types):
-            raise UserDBValueError("Invalid 'public_key': {!r}".format(value))
-        self._data['public_key'] = value
 
 
 def u2f_from_dict(data, raise_on_unknown=True):
@@ -268,54 +97,16 @@ def u2f_from_dict(data, raise_on_unknown=True):
     :type raise_on_unknown: bool
     :rtype: U2F
     """
-    return U2F.from_dict(data, raise_on_unknown=raise_on_unknown)
+    return U2F.from_dict(data)
 
 
+@dataclass
 class Webauthn(FidoCredential):
     """
     Webauthn token authentication credential
     """
-
-    def __init__(
-        self,
-        keyhandle: Optional[str] = None,
-        credential_data: Optional[str] = None,
-        app_id: Optional[str] = None,
-        attest_obj: Optional[str] = None,
-        description: Optional[str] = None,
-        application: Optional[str] = None,
-        created_ts: Optional[Union[datetime, bool]] = None,
-        data: Optional[Dict[str, Any]] = None,
-        raise_on_unknown: bool = True,
-        called_directly: bool = True,
-    ):
-        raise NotImplementedError()
-
-    @classmethod
-    def from_dict(
-        cls: Type[Webauthn], data: Dict[str, Any], raise_on_unknown: bool = True
-    ) -> Webauthn:
-        """
-        Construct U2F credential from a data dict.
-        """
-        data_in = data
-        data = copy.copy(data_in)  # to not modify callers data
-
-        if 'created_ts' not in data:
-            data['created_ts'] = True
-
-        self = super().from_dict(data)
-
-        self.attest_obj = data.pop('attest_obj', '')
-        self.credential_data = data.pop('credential_data', '')
-
-        if raise_on_unknown:
-            self.check_unknown_data(data)
-
-        # Just keep everything that is left as-is
-        self._data.update(data)
-
-        return self
+    attest_obj: str = ''
+    credential_data: str = ''
 
     @property
     def key(self):
@@ -323,49 +114,6 @@ class Webauthn(FidoCredential):
         Return the element that is used as key.
         """
         return 'sha256:' + sha256(self.keyhandle.encode('utf-8') + self.credential_data.encode('utf-8')).hexdigest()
-
-    @property
-    def attest_obj(self):
-        """
-        The Webauthn attestation object for the credential.
-
-        We should probably refine what we store here later on, but for now we just
-        store the whole object.
-
-        :return: Webauthn attest_obj
-        :rtype: str
-        """
-        return self._data['attest_obj']
-
-    @attest_obj.setter
-    def attest_obj(self, value):
-        """
-        :param value: Webauthn attest_obj.
-        :type value: str
-        """
-        if not isinstance(value, string_types):
-            raise UserDBValueError("Invalid 'attest_obj': {!r}".format(value))
-        self._data['attest_obj'] = value
-
-    @property
-    def credential_data(self):
-        """
-        This is the credential data of the Webauthn token.
-
-        :return: Webauthn credential data
-        :rtype: str
-        """
-        return self._data['credential_data']
-
-    @credential_data.setter
-    def credential_data(self, value):
-        """
-        :param value: Webauthn credential data
-        :type value: str
-        """
-        if not isinstance(value, string_types):
-            raise UserDBValueError("Invalid 'credential_data': {!r}".format(value))
-        self._data['credential_data'] = value
 
 
 def webauthn_from_dict(data, raise_on_unknown=True):
@@ -379,4 +127,4 @@ def webauthn_from_dict(data, raise_on_unknown=True):
     :type raise_on_unknown: bool
     :rtype: Webauthn
     """
-    return Webauthn.from_dict(data, raise_on_unknown=raise_on_unknown)
+    return Webauthn.from_dict(data)

--- a/src/eduid_userdb/credentials/fido.py
+++ b/src/eduid_userdb/credentials/fido.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from hashlib import sha256
-from typing import Any, ClassVar, Dict, Optional
+from typing import Any, Dict, Optional
 
 from eduid_userdb.credentials import Credential
 
@@ -62,6 +62,17 @@ class FidoCredential(Credential, _FidoCredentialRequired):
 
     description: str = ''
 
+    def data_out_transforms(self, data: Dict[str, Any], old_userdb_format: bool = False) -> Dict[str, Any]:
+        """
+        Transform data kept in pythonic format into eduid format.
+        """
+        if 'created_by' in data:
+            data['application'] = data.pop('created_by')
+
+        data = super().data_out_transforms(data, old_userdb_format)
+
+        return data
+
 
 @dataclass
 class _U2FCredentialRequired:
@@ -81,8 +92,6 @@ class U2F(FidoCredential, _U2FCredentialRequired):
     """
 
     attest_cert: Optional[str] = None
-
-    name_mapping: ClassVar[Dict[str, str]] = {'application': 'created_by'}
 
     @property
     def key(self) -> str:
@@ -111,8 +120,6 @@ class Webauthn(FidoCredential):
 
     attest_obj: str = ''
     credential_data: str = ''
-
-    name_mapping: ClassVar[Dict[str, str]] = {'application': 'created_by'}
 
     @property
     def key(self) -> str:

--- a/src/eduid_userdb/credentials/fido.py
+++ b/src/eduid_userdb/credentials/fido.py
@@ -62,14 +62,14 @@ class FidoCredential(Credential, _FidoCredentialRequired):
 
     description: str = ''
 
-    def data_out_transforms(self, data: Dict[str, Any], old_userdb_format: bool = False) -> Dict[str, Any]:
+    def _data_out_transforms(self, data: Dict[str, Any], old_userdb_format: bool = False) -> Dict[str, Any]:
         """
         Transform data kept in pythonic format into eduid format.
         """
         if 'created_by' in data:
             data['application'] = data.pop('created_by')
 
-        data = super().data_out_transforms(data, old_userdb_format)
+        data = super()._data_out_transforms(data, old_userdb_format)
 
         return data
 

--- a/src/eduid_userdb/credentials/fido.py
+++ b/src/eduid_userdb/credentials/fido.py
@@ -49,6 +49,7 @@ class _FidoCredentialRequired:
     Required fields for FidoCredential, so that they go before the optional
     arguments of Element in the implicit constructor.
     """
+
     keyhandle: str
     app_id: str
 
@@ -58,6 +59,7 @@ class FidoCredential(Credential, _FidoCredentialRequired):
     """
     Token authentication credential
     """
+
     description: str = ''
 
 
@@ -67,6 +69,7 @@ class _U2FCredentialRequired:
     Required fields for U2F, so that they go before the optional
     arguments in the implicit constructor.
     """
+
     version: str
     public_key: str
 
@@ -76,6 +79,7 @@ class U2F(FidoCredential, _U2FCredentialRequired):
     """
     U2F token authentication credential
     """
+
     attest_cert: Optional[str] = None
 
     name_mapping: ClassVar[Dict[str, str]] = {'application': 'created_by'}
@@ -104,6 +108,7 @@ class Webauthn(FidoCredential):
     """
     Webauthn token authentication credential
     """
+
     attest_obj: str = ''
     credential_data: str = ''
 

--- a/src/eduid_userdb/credentials/fido.py
+++ b/src/eduid_userdb/credentials/fido.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from hashlib import sha256
-from typing import Optional
+from typing import ClassVar, Dict, Optional
 
 from eduid_userdb.credentials import Credential
 
@@ -78,6 +78,8 @@ class U2F(FidoCredential, _U2FCredentialRequired):
     """
     attest_cert: Optional[str] = None
 
+    name_mapping: ClassVar[Dict[str, str]] = {'application': 'created_by'}
+
     @property
     def key(self):
         """
@@ -107,6 +109,8 @@ class Webauthn(FidoCredential):
     """
     attest_obj: str = ''
     credential_data: str = ''
+
+    name_mapping: ClassVar[Dict[str, str]] = {'application': 'created_by'}
 
     @property
     def key(self):

--- a/src/eduid_userdb/credentials/password.py
+++ b/src/eduid_userdb/credentials/password.py
@@ -55,8 +55,8 @@ class Password(Credential, _PasswordRequired):
     """
     is_generated: bool = False
 
-    name_mapping = {'source': 'created_by', 'id': 'credential_id'}
-    old_names = ('source', 'id', 'application')
+    name_mapping = {'application': 'created_by', 'source': 'created_by', 'id': 'credential_id'}
+    old_names = ('source',)
 
     @property
     def key(self) -> str:

--- a/src/eduid_userdb/credentials/password.py
+++ b/src/eduid_userdb/credentials/password.py
@@ -35,7 +35,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, Type
 
 from eduid_userdb.credentials import Credential
 
@@ -56,21 +55,8 @@ class Password(Credential, _PasswordRequired):
     """
     is_generated: bool = False
 
-    @classmethod
-    def massage_data(
-        cls: Type[Password], data: Dict[str, Any]
-    ) -> Dict[str, Any]:
-        """
-        Construct password credential from a data dict.
-        """
-        data = super().massage_data(data)
-
-        if 'source' in data:  # TODO: Load and save all users in the database to replace source with created_by
-            data['created_by'] = data.pop('source')
-        if 'id' in data:  # TODO: Load and save all users in the database to replace id with credential_id
-            data['credential_id'] = data.pop('id')
-
-        return data
+    name_mapping = {'source': 'created_by', 'id': 'credential_id'}
+    old_names = ('source', 'id')
 
     @property
     def key(self) -> str:

--- a/src/eduid_userdb/credentials/password.py
+++ b/src/eduid_userdb/credentials/password.py
@@ -65,6 +65,8 @@ class Password(Credential, _PasswordRequired):
         """
         data = super().massage_data(data)
 
+        if 'source' in data:  # TODO: Load and save all users in the database to replace source with created_by
+            data['created_by'] = data.pop('source')
         if 'id' in data:  # TODO: Load and save all users in the database to replace id with credential_id
             data['credential_id'] = data.pop('id')
 

--- a/src/eduid_userdb/credentials/password.py
+++ b/src/eduid_userdb/credentials/password.py
@@ -64,7 +64,7 @@ class Password(Credential, _PasswordRequired):
     """
     is_generated: bool = False
 
-    name_mapping = {'application': 'created_by', 'source': 'created_by', 'id': 'credential_id'}
+    name_mapping = {'source': 'created_by', 'id': 'credential_id'}
     old_names = ('source', 'id')
 
     @property

--- a/src/eduid_userdb/credentials/password.py
+++ b/src/eduid_userdb/credentials/password.py
@@ -74,11 +74,11 @@ class Password(Credential, _PasswordRequired):
         return self.credential_id
 
     @classmethod
-    def _data_in_transforms(cls: Type[Password], data: Dict[str, Any]) -> Dict[str, Any]:
+    def _from_dict_transform(cls: Type[Password], data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Transform data received in eduid format into pythonic format.
         """
-        data = super()._data_in_transforms(data)
+        data = super()._from_dict_transform(data)
 
         if 'source' in data:
             data['created_by'] = data.pop('source')
@@ -88,12 +88,12 @@ class Password(Credential, _PasswordRequired):
 
         return data
 
-    def _data_out_transforms(self, data: Dict[str, Any]) -> Dict[str, Any]:
+    def _to_dict_transform(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Transform data kept in pythonic format into eduid format.
         """
 
-        data = super()._data_out_transforms(data)
+        data = super()._to_dict_transform(data)
 
         return data
 

--- a/src/eduid_userdb/credentials/password.py
+++ b/src/eduid_userdb/credentials/password.py
@@ -49,6 +49,7 @@ class _PasswordRequired:
     """
     Required fields for Password
     """
+
     credential_id: str
     salt: str
 
@@ -62,6 +63,7 @@ class _PasswordRequired:
 class Password(Credential, _PasswordRequired):
     """
     """
+
     is_generated: bool = False
 
     name_mapping = {'source': 'created_by', 'id': 'credential_id'}

--- a/src/eduid_userdb/credentials/password.py
+++ b/src/eduid_userdb/credentials/password.py
@@ -56,7 +56,7 @@ class Password(Credential, _PasswordRequired):
     is_generated: bool = False
 
     name_mapping = {'source': 'created_by', 'id': 'credential_id'}
-    old_names = ('source',)
+    old_names = ('source', 'id', 'application')
 
     @property
     def key(self) -> str:

--- a/src/eduid_userdb/credentials/password.py
+++ b/src/eduid_userdb/credentials/password.py
@@ -35,6 +35,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any, Dict
 
 import bson
 
@@ -46,6 +47,7 @@ __author__ = 'lundberg'
 @dataclass
 class _PasswordRequired:
     """
+    Required fields for Password
     """
     credential_id: str
     salt: str
@@ -56,7 +58,7 @@ class _PasswordRequired:
             self.credential_id = str(self.credential_id)
 
 
-@dataclass
+@dataclass(eq=False, unsafe_hash=True)
 class Password(Credential, _PasswordRequired):
     """
     """
@@ -73,15 +75,12 @@ class Password(Credential, _PasswordRequired):
         return self.credential_id
 
 
-def password_from_dict(data, raise_on_unknown=True):
+def password_from_dict(data: Dict[str, Any], raise_on_unknown: bool = True) -> Password:
     """
     Create a Password instance from a dict.
 
     :param data: Password parameters from database
     :param raise_on_unknown: Raise UserHasUnknownData if unrecognized data is encountered
-
-    :type data: dict
-    :type raise_on_unknown: bool
-    :rtype: Password
+                             kept for B/C
     """
     return Password.from_dict(data)

--- a/src/eduid_userdb/credentials/password.py
+++ b/src/eduid_userdb/credentials/password.py
@@ -88,18 +88,12 @@ class Password(Credential, _PasswordRequired):
 
         return data
 
-    def _data_out_transforms(self, data: Dict[str, Any], old_userdb_format: bool = False) -> Dict[str, Any]:
+    def _data_out_transforms(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Transform data kept in pythonic format into eduid format.
         """
-        if old_userdb_format:
-            if 'created_by' in data:
-                data['source'] = data.pop('created_by')
 
-            if 'credential_id' in data:
-                data['id'] = data.pop('credential_id')
-
-        data = super()._data_out_transforms(data, old_userdb_format)
+        data = super()._data_out_transforms(data)
 
         return data
 

--- a/src/eduid_userdb/credentials/password.py
+++ b/src/eduid_userdb/credentials/password.py
@@ -63,7 +63,7 @@ class Password(Credential, _PasswordRequired):
     is_generated: bool = False
 
     name_mapping = {'application': 'created_by', 'source': 'created_by', 'id': 'credential_id'}
-    old_names = ('source',)
+    old_names = ('source', 'id')
 
     @property
     def key(self) -> str:

--- a/src/eduid_userdb/credentials/password.py
+++ b/src/eduid_userdb/credentials/password.py
@@ -36,6 +36,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+import bson
+
 from eduid_userdb.credentials import Credential
 
 __author__ = 'lundberg'
@@ -47,6 +49,11 @@ class _PasswordRequired:
     """
     credential_id: str
     salt: str
+
+    def __post_init__(self):
+        # backwards compat
+        if isinstance(self.credential_id, bson.ObjectId):
+            self.credential_id = str(self.credential_id)
 
 
 @dataclass

--- a/src/eduid_userdb/credentials/password.py
+++ b/src/eduid_userdb/credentials/password.py
@@ -43,7 +43,7 @@ __author__ = 'lundberg'
 
 
 @dataclass
-class _PasswordRequired(Credential):
+class _PasswordRequired:
     """
     """
     credential_id: str

--- a/src/eduid_userdb/credentials/password.py
+++ b/src/eduid_userdb/credentials/password.py
@@ -59,7 +59,7 @@ class _PasswordRequired:
             self.credential_id = str(self.credential_id)
 
 
-@dataclass(eq=False, unsafe_hash=True)
+@dataclass
 class Password(Credential, _PasswordRequired):
     """
     """

--- a/src/eduid_userdb/credentials/password.py
+++ b/src/eduid_userdb/credentials/password.py
@@ -56,7 +56,7 @@ class Password(Credential, _PasswordRequired):
     is_generated: bool = False
 
     name_mapping = {'source': 'created_by', 'id': 'credential_id'}
-    old_names = ('source', 'id')
+    old_names = ('source',)
 
     @property
     def key(self) -> str:

--- a/src/eduid_userdb/credentials/password.py
+++ b/src/eduid_userdb/credentials/password.py
@@ -35,7 +35,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict
+from typing import Any, Dict, Type
 
 import bson
 
@@ -75,6 +75,36 @@ class Password(Credential, _PasswordRequired):
         Return the element that is used as key.
         """
         return self.credential_id
+
+    @staticmethod
+    def data_in_transforms(cls: Type[Password], data: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Transform data received in eduid format into pythonic format.
+        """
+        data = super().data_in_transforms(data)
+
+        if 'source' in data:
+            data['created_by'] = data.pop('source')
+
+        if 'id' in data:
+            data['credential_id'] = data.pop('id')
+
+        return data
+
+    def data_out_transforms(self, data: Dict[str, Any], old_userdb_format: bool = False) -> Dict[str, Any]:
+        """
+        Transform data kept in pythonic format into eduid format.
+        """
+        if old_userdb_format:
+            if 'created_by' in data:
+                data['source'] = data.pop('created_by')
+
+            if 'credential_id' in data:
+                data['id'] = data.pop('credential_id')
+
+        data = super().data_out_transforms(data, old_userdb_format)
+
+        return data
 
 
 def password_from_dict(data: Dict[str, Any], raise_on_unknown: bool = True) -> Password:

--- a/src/eduid_userdb/credentials/password.py
+++ b/src/eduid_userdb/credentials/password.py
@@ -66,9 +66,6 @@ class Password(Credential, _PasswordRequired):
 
     is_generated: bool = False
 
-    name_mapping = {'source': 'created_by', 'id': 'credential_id'}
-    old_names = ('source', 'id')
-
     @property
     def key(self) -> str:
         """
@@ -76,12 +73,12 @@ class Password(Credential, _PasswordRequired):
         """
         return self.credential_id
 
-    @staticmethod
-    def data_in_transforms(cls: Type[Password], data: Dict[str, Any]) -> Dict[str, Any]:
+    @classmethod
+    def _data_in_transforms(cls: Type[Password], data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Transform data received in eduid format into pythonic format.
         """
-        data = super().data_in_transforms(data)
+        data = super()._data_in_transforms(data)
 
         if 'source' in data:
             data['created_by'] = data.pop('source')
@@ -91,7 +88,7 @@ class Password(Credential, _PasswordRequired):
 
         return data
 
-    def data_out_transforms(self, data: Dict[str, Any], old_userdb_format: bool = False) -> Dict[str, Any]:
+    def _data_out_transforms(self, data: Dict[str, Any], old_userdb_format: bool = False) -> Dict[str, Any]:
         """
         Transform data kept in pythonic format into eduid format.
         """
@@ -102,7 +99,7 @@ class Password(Credential, _PasswordRequired):
             if 'credential_id' in data:
                 data['id'] = data.pop('credential_id')
 
-        data = super().data_out_transforms(data, old_userdb_format)
+        data = super()._data_out_transforms(data, old_userdb_format)
 
         return data
 

--- a/src/eduid_userdb/dashboard/user.py
+++ b/src/eduid_userdb/dashboard/user.py
@@ -91,8 +91,8 @@ class DashboardUser(User):
         old_data = self._data.get('letter_proofing_data', [])
         self._data['letter_proofing_data'] = old_data + [data]
 
-    def to_dict(self, old_userdb_format=False):
-        res = User.to_dict(self, old_userdb_format=old_userdb_format)
+    def to_dict(self):
+        res = User.to_dict(self)
         res['terminated'] = self.terminated
         return res
 

--- a/src/eduid_userdb/element.py
+++ b/src/eduid_userdb/element.py
@@ -257,7 +257,6 @@ class Element(metaclass=MetaElement):
         To be overridden in subclasses that know specifically how to transform the data.
 
         The default implementation removes the attributes with None value
-        and then tries to delegate to super()
         """
         new_data = dict()
         for key, val in data.items():

--- a/src/eduid_userdb/element.py
+++ b/src/eduid_userdb/element.py
@@ -98,7 +98,7 @@ class MetaElement(type):
         mapping = {}
         old_names = ()
 
-        for cls in elem_class.__mro__:
+        for cls in reversed(elem_class.__mro__):
 
             if hasattr(cls, 'name_mapping'):
                 mapping.update(cls.name_mapping)

--- a/src/eduid_userdb/element.py
+++ b/src/eduid_userdb/element.py
@@ -531,7 +531,7 @@ def _set_something_ts(data, key, value, allow_update=False):
     if value is None:
         return
     if value is True:
-        value = datetime.datetime.utcnow()
-    if not isinstance(value, datetime.datetime):
+        value = datetime.utcnow()
+    if not isinstance(value, datetime):
         raise UserDBValueError("Invalid {!r} value: {!r}".format(key, value))
     data[key] = value

--- a/src/eduid_userdb/element.py
+++ b/src/eduid_userdb/element.py
@@ -91,7 +91,7 @@ from __future__ import annotations
 import copy
 from datetime import datetime
 from dataclasses import dataclass, asdict, field
-from typing import Any, ClassVar, Dict, List, Optional, Type, TypeVar
+from typing import cast, Any, ClassVar, Dict, List, Optional, Type, TypeVar
 
 from six import string_types
 
@@ -138,7 +138,7 @@ TElementSubclass = TypeVar('TElementSubclass', bound='Element')
 
 class MetaElement(type):
 
-    def __new__(typ, name, bases, dct):
+    def __new__(typ: Type[MetaElement], name: str, bases: tuple, dct: dict) -> MetaElement:
         """
         Here we modify the construction of the Element class and its subclasses,
         to be able to inherit the mappings of attribute names.
@@ -164,7 +164,9 @@ class MetaElement(type):
         dct['inverse_name_mapping'] = {v: k for k, v in mapping.items()}
         dct['old_names'] = tuple(set(old))
 
-        return super().__new__(typ, name, bases, dct)
+        result = super().__new__(typ, name, bases, dct)
+
+        return cast(MetaElement, result)
 
 
 @dataclass

--- a/src/eduid_userdb/element.py
+++ b/src/eduid_userdb/element.py
@@ -205,10 +205,14 @@ class Element(metaclass=MetaElement):
     def data_out_transforms(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """
         """
+        new_data = dict()
+        for key, val in data.items():
+            if val is not None:
+                new_data[key] = val
         try:
-            return super().data_out_transforms(data)
+            return super().data_out_transforms(new_data)
         except AttributeError:
-            return data
+            return new_data
 
 
 @dataclass

--- a/src/eduid_userdb/element.py
+++ b/src/eduid_userdb/element.py
@@ -224,8 +224,6 @@ class PrimaryElement(VerifiedElement):
         if leftovers:
             if raise_on_unknown:
                 raise UserHasUnknownData(f'{self.__class__.__name__} has unknown data: {leftovers}')
-            # Just keep everything that is left as-is
-            self._data.update(data)
 
         return self
 

--- a/src/eduid_userdb/element.py
+++ b/src/eduid_userdb/element.py
@@ -59,8 +59,7 @@ dataclass objects, and in eduid format is in the form of dictionaries / JSON.
 Additionally, some of the attribute names that were used in the past have been
 deprecated. An example is the pythonic attribute name `created_by`, which in
 some elements was translated to eduid format as `source`. We want to be able to
-ingest (in `from_dict`) data in the old format, and only produce data in the
-old format if `to_dict` is called with `old_userdb_format=True`.
+ingest (in `from_dict`) data in the old format.
 
 There is also sometimes data in the eduid format dicts that we simply want
 to ignore. An example is `verification_code` in VerifiedElement.
@@ -143,6 +142,10 @@ class Element:
     created_by: Optional[str] = None
     created_ts: datetime = field(default_factory=datetime.utcnow)
     modified_ts: datetime = field(default_factory=datetime.utcnow)
+    # This is a short-term hack to deploy new dataclass based elements without
+    # any changes to data in the production database. Remove after a burn-in period.
+    _no_created_ts_in_db: bool = False
+    _no_modified_ts_in_db: bool = False
 
     def __str__(self) -> str:
         return f'<eduID {self.__class__.__name__}: {asdict(self)}>'
@@ -161,16 +164,14 @@ class Element:
 
         return cls(**data)
 
-    def to_dict(self, old_userdb_format: bool = False) -> Dict[str, Any]:
+    def to_dict(self) -> Dict[str, Any]:
         """
         Convert Element to a dict in eduid format, that can be used to reconstruct the
         Element later.
-
-        :param old_userdb_format: Set to True to get data back in legacy format.
         """
         data = asdict(self)
 
-        data = self._data_out_transforms(data, old_userdb_format)
+        data = self._data_out_transforms(data)
 
         return data
 
@@ -182,15 +183,36 @@ class Element:
         if 'application' in data:
             data['created_by'] = data.pop('application')
 
+        if 'added_timestamp' in data:
+            data['created_ts'] = data.pop('added_timestamp')
+
+        if 'created_ts' not in data:
+            # some really old nin entries in the database have neither created_ts nor modified_ts
+            data['_no_created_ts_in_db'] = True
+            data['created_ts'] = datetime.fromisoformat('1900-01-01')
+
+        if 'modified_ts' not in data:
+            data['_no_modified_ts_in_db'] = True
+            # Use created_ts as modified_ts if no explicit modified_ts was found
+            data['modified_ts'] = data['created_ts']
+
         return data
 
-    def _data_out_transforms(self, data: Dict[str, Any], old_userdb_format: bool = False) -> Dict[str, Any]:
+    def _data_out_transforms(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Transform data kept in pythonic format into eduid format.
         """
-        if old_userdb_format:
-            if 'created_by' in data:
-                data['application'] = data.pop('created_by')
+        # If there was no modified_ts in the data that was loaded from the database,
+        # don't write one back if it matches the implied one of created_ts
+        if '_no_modified_ts_in_db' in data:
+            if data.pop('_no_modified_ts_in_db') is True:
+                if data.get('modified_ts') == data.get('created_ts'):
+                    del data['modified_ts']
+
+        if '_no_created_ts_in_db' in data:
+            if data.pop('_no_created_ts_in_db') is True:
+                if 'created_ts' in data:
+                    del data['created_ts']
 
         # remove None values
         data = {k: v for k, v in data.items() if v is not None}
@@ -234,7 +256,7 @@ class VerifiedElement(Element):
 
         return data
 
-    def _data_out_transforms(self, data: Dict[str, Any], old_userdb_format: bool = False) -> Dict[str, Any]:
+    def _data_out_transforms(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Transform data kept in pythonic format into eduid format.
         """
@@ -278,7 +300,7 @@ class PrimaryElement(VerifiedElement):
 
         return data
 
-    def _data_out_transforms(self, data: Dict[str, Any], old_userdb_format: bool = False) -> Dict[str, Any]:
+    def _data_out_transforms(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Transform data kept in pythonic format into eduid format.
         """
@@ -316,17 +338,13 @@ class ElementList(object):
         """
         return self._elements
 
-    def to_list_of_dicts(self, old_userdb_format=False):
+    def to_list_of_dicts(self) -> List[Dict[str, Any]]:
         """
         Get the elements in a serialized format that can be stored in MongoDB.
 
-        :param old_userdb_format: Set to True to get data back in legacy format.
-        :type old_userdb_format: bool
-
         :return: List of dicts
-        :rtype: [dict]
         """
-        return [this.to_dict(old_userdb_format=old_userdb_format) for this in self._elements]
+        return [this.to_dict() for this in self._elements]
 
     def find(self, key):
         """

--- a/src/eduid_userdb/element.py
+++ b/src/eduid_userdb/element.py
@@ -137,7 +137,7 @@ class Element(metaclass=MetaElement):
     modified_ts: datetime = field(default_factory=datetime.utcnow)
 
     name_mapping: ClassVar[Dict[str, str]] = {'application': 'created_by'}
-    old_names: ClassVar[tuple] = ()
+    old_names: ClassVar[tuple] = ('application',)
 
     _name_mapping: ClassVar[Dict[str, str]] = {}
     _inverse_name_mapping: ClassVar[Dict[str, str]] = {}

--- a/src/eduid_userdb/element.py
+++ b/src/eduid_userdb/element.py
@@ -89,9 +89,9 @@ and can be overridden in subclasses.
 from __future__ import annotations
 
 import copy
+from dataclasses import asdict, dataclass, field
 from datetime import datetime
-from dataclasses import dataclass, asdict, field
-from typing import cast, Any, ClassVar, Dict, List, Optional, Type, TypeVar
+from typing import Any, ClassVar, Dict, List, Optional, Type, TypeVar, cast
 
 from six import string_types
 
@@ -137,7 +137,6 @@ TElementSubclass = TypeVar('TElementSubclass', bound='Element')
 
 
 class MetaElement(type):
-
     def __new__(typ: Type[MetaElement], name: str, bases: tuple, dct: dict) -> MetaElement:
         """
         Here we modify the construction of the Element class and its subclasses,
@@ -181,6 +180,7 @@ class Element(metaclass=MetaElement):
                 PrimaryElement
             EventElement
     """
+
     created_by: Optional[str] = None
     created_ts: datetime = field(default_factory=datetime.utcnow)
     modified_ts: datetime = field(default_factory=datetime.utcnow)
@@ -270,6 +270,7 @@ class VerifiedElement(Element):
     """
     Elements that can be verified or not.
     """
+
     is_verified: bool = False
     verified_by: Optional[str] = None
     verified_ts: Optional[datetime] = None
@@ -282,6 +283,7 @@ class PrimaryElement(VerifiedElement):
     """
     Elements that can be either primary or not.
     """
+
     is_primary: bool = False
 
     name_mapping: ClassVar[Dict[str, str]] = {'primary': 'is_primary'}

--- a/src/eduid_userdb/element.py
+++ b/src/eduid_userdb/element.py
@@ -206,6 +206,9 @@ class Element:
         raise NotImplementedError("'key' not implemented for Element subclass")
 
 
+TVerifiedElementSubclass = TypeVar('TVerifiedElementSubclass', bound='VerifiedElement')
+
+
 @dataclass
 class VerifiedElement(Element):
     """
@@ -217,7 +220,7 @@ class VerifiedElement(Element):
     verified_ts: Optional[datetime] = None
 
     @classmethod
-    def _data_in_transforms(cls: Type[TElementSubclass], data: Dict[str, Any]) -> Dict[str, Any]:
+    def _data_in_transforms(cls: Type[TVerifiedElementSubclass], data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Transform data received in eduid format into pythonic format.
         """
@@ -243,6 +246,9 @@ class VerifiedElement(Element):
         return data
 
 
+TPrimaryElementSubclass = TypeVar('TPrimaryElementSubclass', bound='PrimaryElement')
+
+
 @dataclass
 class PrimaryElement(VerifiedElement):
     """
@@ -261,7 +267,7 @@ class PrimaryElement(VerifiedElement):
         super().__setattr__(key, value)
 
     @classmethod
-    def _data_in_transforms(cls: Type[TElementSubclass], data: Dict[str, Any]) -> Dict[str, Any]:
+    def _data_in_transforms(cls: Type[TPrimaryElementSubclass], data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Transform data received in eduid format into pythonic format.
         """

--- a/src/eduid_userdb/element.py
+++ b/src/eduid_userdb/element.py
@@ -71,9 +71,9 @@ semantically sound. For example, we don't want data representing an element
 with the `is_primary` attribute set to `True` but the `is_verified` attribute
 set to `False`.
 
-To do the name translation, we use a mapping set as a class attribute in the
+To do the name translation, we use a mapping, set as a class attribute in the
 dataclasses (the dataclass machinery leaves alone such attributes), with the
-eduid names as keys and the pythonic names as values. We make this inheritble
+eduid names as keys and the pythonic names as values. We make this inheritable
 (in the sense that subclasses will merge the mappings declared in its
 superclasses with the mapping declared for themselves) by providing them with
 a metaclass that does the aggregation.

--- a/src/eduid_userdb/element.py
+++ b/src/eduid_userdb/element.py
@@ -86,6 +86,8 @@ To enforce arbitrary constraints we provide 2 methods, `data_in_transforms` and
 and can be overridden in subclasses.
 
 """
+from __future__ import annotations
+
 import copy
 from datetime import datetime
 from dataclasses import dataclass, asdict, field
@@ -133,9 +135,12 @@ class PrimaryElementViolation(PrimaryElementError):
 
 TElementSubclass = TypeVar('TElementSubclass', bound='Element')
 
+TType = TypeVar('TType', bound=type)
+
 
 class MetaElement(type):
-    def __new__(typ, name: str, bases: tuple, dct: dict):
+
+    def __new__(typ: Type[MetaElement], name: str, bases: tuple, dct: dict) -> MetaElement:
         """
         Here we modify the construction of the Element class and its subclasses,
         to be able to inherit the mappings of attribute names.
@@ -147,11 +152,13 @@ class MetaElement(type):
 
         for cls in reversed(elem_class.__mro__):
 
-            if hasattr(cls, 'name_mapping'):
-                mapping.update(cls.name_mapping)
+            if cls is not type:
 
-            if hasattr(cls, 'old_names'):
-                old_names += cls.old_names
+                if hasattr(cls, 'name_mapping'):
+                    mapping.update(cls.name_mapping)
+
+                if hasattr(cls, 'old_names'):
+                    old_names += cls.old_names
 
         elem_class._name_mapping = mapping
         elem_class._inverse_name_mapping = {v: k for k, v in mapping.items()}

--- a/src/eduid_userdb/element.py
+++ b/src/eduid_userdb/element.py
@@ -71,7 +71,7 @@ with the `is_primary` attribute set to `True` but the `is_verified` attribute
 set to `False`.
 
 To translate between the data formats, and to enforce arbitrary constraints we
-provide 2 methods, `_data_in_transforms` and `_data_out_transforms`, that are
+provide 2 methods, `_from_dict_transform` and `_to_dict_transform`, that are
 respectively called in `from_dict` and `to_dict` and can be overridden in
 subclasses.
 
@@ -160,7 +160,7 @@ class Element:
 
         data = copy.deepcopy(data)  # to not modify callers data
 
-        data = cls._data_in_transforms(data)
+        data = cls._from_dict_transform(data)
 
         return cls(**data)
 
@@ -171,12 +171,12 @@ class Element:
         """
         data = asdict(self)
 
-        data = self._data_out_transforms(data)
+        data = self._to_dict_transform(data)
 
         return data
 
     @classmethod
-    def _data_in_transforms(cls: Type[TElementSubclass], data: Dict[str, Any]) -> Dict[str, Any]:
+    def _from_dict_transform(cls: Type[TElementSubclass], data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Transform data received in eduid format into pythonic format.
         """
@@ -198,7 +198,7 @@ class Element:
 
         return data
 
-    def _data_out_transforms(self, data: Dict[str, Any]) -> Dict[str, Any]:
+    def _to_dict_transform(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Transform data kept in pythonic format into eduid format.
         """
@@ -242,11 +242,11 @@ class VerifiedElement(Element):
     verified_ts: Optional[datetime] = None
 
     @classmethod
-    def _data_in_transforms(cls: Type[TVerifiedElementSubclass], data: Dict[str, Any]) -> Dict[str, Any]:
+    def _from_dict_transform(cls: Type[TVerifiedElementSubclass], data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Transform data received in eduid format into pythonic format.
         """
-        data = super()._data_in_transforms(data)
+        data = super()._from_dict_transform(data)
 
         if 'verified' in data:
             data['is_verified'] = data.pop('verified')
@@ -256,14 +256,14 @@ class VerifiedElement(Element):
 
         return data
 
-    def _data_out_transforms(self, data: Dict[str, Any]) -> Dict[str, Any]:
+    def _to_dict_transform(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Transform data kept in pythonic format into eduid format.
         """
         if 'is_verified' in data:
             data['verified'] = data.pop('is_verified')
 
-        data = super()._data_out_transforms(data)
+        data = super()._to_dict_transform(data)
 
         return data
 
@@ -289,25 +289,25 @@ class PrimaryElement(VerifiedElement):
         super().__setattr__(key, value)
 
     @classmethod
-    def _data_in_transforms(cls: Type[TPrimaryElementSubclass], data: Dict[str, Any]) -> Dict[str, Any]:
+    def _from_dict_transform(cls: Type[TPrimaryElementSubclass], data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Transform data received in eduid format into pythonic format.
         """
-        data = super()._data_in_transforms(data)
+        data = super()._from_dict_transform(data)
 
         if 'primary' in data:
             data['is_primary'] = data.pop('primary')
 
         return data
 
-    def _data_out_transforms(self, data: Dict[str, Any]) -> Dict[str, Any]:
+    def _to_dict_transform(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Transform data kept in pythonic format into eduid format.
         """
         if 'is_primary' in data:
             data['primary'] = data.pop('is_primary')
 
-        data = super()._data_out_transforms(data)
+        data = super()._to_dict_transform(data)
 
         return data
 

--- a/src/eduid_userdb/element.py
+++ b/src/eduid_userdb/element.py
@@ -43,9 +43,9 @@ In Python code we deal with data in pythonic format. Outside Python code (in
 the DB, or when sending data to the front, or also in data samples for testing)
 we deal with data in eduid format.
 
-The interface between both formats is provided by the methods `from_dict` (to
-convert data in eduid format to data in pythonic format) and `to_dict` (to
-convert data in the opposite direction).
+The interface between both formats is given by the `Element`'s methods
+`from_dict` (to convert data in eduid format to data in pythonic format) and
+`to_dict` (to convert data in the opposite direction).
 
 The main differences between both formats are, in one hand, the names of the
 attributes, that may change from one format to the other. For example, the
@@ -56,11 +56,11 @@ On another hand, the representation of complex data (i.e., not of basic types:
 string, boolean, integer, bytes), differs: in pythonic format is in the form of
 dataclass objects, and in eduid format is in the form of dictionaries / JSON.
 
-Additionally, some of the pythonic attribute names that were used in the past
-have been deprecated. An example is the pythonic attribute name `created_by`,
-which in some elements was translated to eduid format as `source`. We want
-to be able to ingest (in `from_dict`) data in the old format, and only produce
-data in the old format if `to_dict` is called with `old_userdb_format=True`.
+Additionally, some of the attribute names that were used in the past have been
+deprecated. An example is the pythonic attribute name `created_by`, which in
+some elements was translated to eduid format as `source`. We want to be able to
+ingest (in `from_dict`) data in the old format, and only produce data in the
+old format if `to_dict` is called with `old_userdb_format=True`.
 
 There is also sometimes data in the eduid format dicts that we simply want
 to ignore. An example is `verification_code` in VerifiedElement.

--- a/src/eduid_userdb/element.py
+++ b/src/eduid_userdb/element.py
@@ -183,8 +183,8 @@ class Element:
 
         return data
 
-    @staticmethod
-    def data_in_transforms(data: Dict[str, Any]) -> Dict[str, Any]:
+    @classmethod
+    def data_in_transforms(cls: Type[TElementSubclass], data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Transform data received in eduid format into pythonic format.
         """
@@ -225,8 +225,8 @@ class VerifiedElement(Element):
     verified_by: Optional[str] = None
     verified_ts: Optional[datetime] = None
 
-    @staticmethod
-    def data_in_transforms(data: Dict[str, Any]) -> Dict[str, Any]:
+    @classmethod
+    def data_in_transforms(cls: Type[TElementSubclass], data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Transform data received in eduid format into pythonic format.
         """
@@ -270,8 +270,8 @@ class PrimaryElement(VerifiedElement):
 
         super().__setattr__(key, value)
 
-    @staticmethod
-    def data_in_transforms(data: Dict[str, Any]) -> Dict[str, Any]:
+    @classmethod
+    def data_in_transforms(cls: Type[TElementSubclass], data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Transform data received in eduid format into pythonic format.
         """

--- a/src/eduid_userdb/element.py
+++ b/src/eduid_userdb/element.py
@@ -165,6 +165,8 @@ class MetaElement(type):
 
         result = super().__new__(typ, name, bases, dct)
 
+        # It seems there's not other waay to do this than casting, see:
+        # https://stackoverflow.com/questions/63054541/how-to-type-the-new-method-in-a-python-metaclass-so-that-mypy-is-happy
         return cast(MetaElement, result)
 
 

--- a/src/eduid_userdb/event.py
+++ b/src/eduid_userdb/event.py
@@ -54,6 +54,7 @@ class EventId(ObjectId):
 class Event(Element):
     """
     """
+
     data: Optional[Dict[str, Any]] = None
     event_type: Optional[str] = None
     event_id: Optional[str] = None

--- a/src/eduid_userdb/event.py
+++ b/src/eduid_userdb/event.py
@@ -59,6 +59,7 @@ class Event(Element):
     event_id: Optional[str] = None
 
     name_mapping: ClassVar[Dict[str, str]] = {'id': 'event_id', 'application': 'created_by'}
+    old_names: ClassVar[tuple] = ('id',)
 
     @property
     def key(self) -> EventId:

--- a/src/eduid_userdb/event.py
+++ b/src/eduid_userdb/event.py
@@ -35,7 +35,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, ClassVar, Dict, List, Optional, Type
 
 from bson import ObjectId
 
@@ -58,7 +58,7 @@ class Event(Element):
     event_type: Optional[str] = None
     event_id: Optional[str] = None
 
-    name_mapping = {'id': 'event_id'}
+    name_mapping: ClassVar[Dict[str, str]] = {'id': 'event_id', 'application': 'created_by'}
 
     @property
     def key(self) -> EventId:

--- a/src/eduid_userdb/event.py
+++ b/src/eduid_userdb/event.py
@@ -112,13 +112,11 @@ class EventList(ElementList):
             raise DuplicateElementViolation("Event {!s} already in list".format(event.key))
         super(EventList, self).add(event)
 
-    def to_list_of_dicts(self, mixed_format: bool = False) -> List[Dict[str, Any]]:
+    def to_list_of_dicts(self) -> List[Dict[str, Any]]:
         """
         Get the elements in a serialized format that can be stored in MongoDB.
-
-        :param mixed_format: Tag each Event with the event_type. Used when list has multiple types of events.
         """
-        return [this.to_dict(mixed_format=mixed_format) for this in self._elements if isinstance(this, Event)]
+        return [this.to_dict() for this in self._elements if isinstance(this, Event)]
 
 
 def event_from_dict(data: Dict[str, Any]):

--- a/src/eduid_userdb/event.py
+++ b/src/eduid_userdb/event.py
@@ -71,11 +71,11 @@ class Event(Element):
         return EventId(self.event_id)
 
     @classmethod
-    def _data_in_transforms(cls: Type[TEventSubclass], data: Dict[str, Any]) -> Dict[str, Any]:
+    def _from_dict_transform(cls: Type[TEventSubclass], data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Transform data received in eduid format into pythonic format.
         """
-        data = super()._data_in_transforms(data)
+        data = super()._from_dict_transform(data)
 
         if 'event_type' not in data:
             data['_no_event_type_in_db'] = True  # Remove this line when Event._no_event_type_in_db is removed
@@ -85,11 +85,11 @@ class Event(Element):
 
         return data
 
-    def _data_out_transforms(self, data: Dict[str, Any]) -> Dict[str, Any]:
+    def _to_dict_transform(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Transform data kept in pythonic format into eduid format.
         """
-        data = super()._data_out_transforms(data)
+        data = super()._to_dict_transform(data)
 
         # If there was no event_type in the data that was loaded from the database,
         # don't write one back if it matches the implied one of 'tou_event'

--- a/src/eduid_userdb/event.py
+++ b/src/eduid_userdb/event.py
@@ -113,11 +113,11 @@ class EventList(ElementList):
             raise DuplicateElementViolation("Event {!s} already in list".format(event.key))
         super(EventList, self).add(event)
 
-    def to_list_of_dicts(self) -> List[Dict[str, Any]]:
+    def to_list_of_dicts(self, old_userdb_format: bool = False) -> List[Dict[str, Any]]:
         """
         Get the elements in a serialized format that can be stored in MongoDB.
         """
-        return [this.to_dict() for this in self._elements if isinstance(this, Event)]
+        return [this.to_dict(old_userdb_format=old_userdb_format) for this in self._elements if isinstance(this, Event)]
 
 
 def event_from_dict(data: Dict[str, Any]):

--- a/src/eduid_userdb/event.py
+++ b/src/eduid_userdb/event.py
@@ -34,7 +34,7 @@
 #
 from __future__ import annotations
 
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Type
 
 from bson import ObjectId
@@ -58,29 +58,8 @@ class Event(Element):
     event_type: Optional[str] = None
     event_id: Optional[str] = None
 
-    @classmethod
-    def massage_data(cls: Type[Event], data: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        """
-        data = super().massage_data(data)
+    name_mapping = {'id': 'event_id'}
 
-        if 'id' in data:  # Compatibility for old format
-            data['event_id'] = data.pop('id')
-
-        return data
-
-    def to_dict(self, mixed_format: bool = False) -> Dict[str, Any]:
-        """
-        Convert Element to a dict, that can be used to reconstruct the Element later.
-
-        :param mixed_format: Tag each Event with the event_type. Used when list has multiple types of events.
-        """
-        res = asdict(self)
-        if not mixed_format and 'event_type' in res:
-            del res['event_type']
-        return res
-
-    # -----------------------------------------------------------------
     @property
     def key(self) -> EventId:
         """ Return the element that is used as key for events in an ElementList. """

--- a/src/eduid_userdb/fixtures/pending_emails.py
+++ b/src/eduid_userdb/fixtures/pending_emails.py
@@ -42,6 +42,5 @@ johnsmith2_example_com_pending = EmailProofingElement.from_dict(
         'verified': False,
         'verified_by': None,
         'verified_ts': None,
-        'primary': False,
     }
 )

--- a/src/eduid_userdb/idp/user.py
+++ b/src/eduid_userdb/idp/user.py
@@ -77,7 +77,7 @@ class IdPUser(User):
 
         :return: SAML attributes
         """
-        attributes_in = self.to_dict(old_userdb_format=True)
+        attributes_in = self.to_dict()
         attributes = {}
         for approved in filter_attributes:
             if approved in attributes_in:

--- a/src/eduid_userdb/locked_identity.py
+++ b/src/eduid_userdb/locked_identity.py
@@ -58,6 +58,7 @@ class LockedIdentityNin(LockedIdentityElement, _LockedIdentityNinRequired):
 
         number
     """
+    identity_type: str = 'nin'
 
     @classmethod
     def massage_data(cls: Type[LockedIdentityElement], data: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/eduid_userdb/locked_identity.py
+++ b/src/eduid_userdb/locked_identity.py
@@ -16,6 +16,7 @@ class _LockedIdentityElementRequired:
     Required fields for LockedElement, so that they go before the optional
     arguments of Element in the implicit constructor.
     """
+
     identity_type: str
 
 
@@ -47,6 +48,7 @@ class _LockedIdentityNinRequired:
     Required fields for LockedElementNin, so that they go before the optional
     arguments of Element in the implicit constructor.
     """
+
     number: str
 
 
@@ -60,6 +62,7 @@ class LockedIdentityNin(LockedIdentityElement, _LockedIdentityNinRequired):
 
         number
     """
+
     identity_type: str = 'nin'
 
     @classmethod
@@ -91,9 +94,7 @@ class LockedIdentityList(ElementList):
                 elements.append(item)
             else:
                 if item['identity_type'] == 'nin':
-                    elements.append(
-                        LockedIdentityNin.from_dict(item)
-                    )
+                    elements.append(LockedIdentityNin.from_dict(item))
         ElementList.__init__(self, elements)
 
     def remove(self, key):

--- a/src/eduid_userdb/locked_identity.py
+++ b/src/eduid_userdb/locked_identity.py
@@ -61,13 +61,13 @@ class LockedIdentityNin(LockedIdentityElement, _LockedIdentityNinRequired):
     identity_type: str = 'nin'
 
     @classmethod
-    def massage_data(cls: Type[LockedIdentityElement], data: Dict[str, Any]) -> Dict[str, Any]:
+    def data_in_transforms(cls: Type[LockedIdentityElement], data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Construct locked identity element from a data dict.
         """
         data['identity_type'] = 'nin'
 
-        data = super().massage_data(data)
+        data = super().data_in_transforms(data)
 
         return data
 

--- a/src/eduid_userdb/locked_identity.py
+++ b/src/eduid_userdb/locked_identity.py
@@ -36,7 +36,7 @@ class LockedIdentityElement(Element, _LockedIdentityElementRequired):
         """
         :return: Type of identity
         """
-        # XXX this is wrong, with a list of locked identity elements we should be able to
+        # XXX this seems wrong: given a list of locked identity elements, we should be able to
         # XXX find or remove elements through their key, so the key should be unique for
         # XXX each locked identity element.
         return self.identity_type

--- a/src/eduid_userdb/locked_identity.py
+++ b/src/eduid_userdb/locked_identity.py
@@ -63,7 +63,7 @@ class LockedIdentityNin(LockedIdentityElement, _LockedIdentityNinRequired):
     identity_type: str = 'nin'
 
     @classmethod
-    def data_in_transforms(cls: Type[LockedIdentityElement], data: Dict[str, Any]) -> Dict[str, Any]:
+    def data_in_transforms(cls: Type[LockedIdentityNin], data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Construct locked identity element from a data dict.
         """

--- a/src/eduid_userdb/locked_identity.py
+++ b/src/eduid_userdb/locked_identity.py
@@ -31,11 +31,13 @@ class LockedIdentityElement(Element, _LockedIdentityElementRequired):
     """
 
     @property
-    def key(self):
+    def key(self) -> str:
         """
         :return: Type of identity
-        :rtype: string_types
         """
+        # XXX this is wrong, with a list of locked identity elements we should be able to
+        # XXX find or remove elements through their key, so the key should be unique for
+        # XXX each locked identity element.
         return self.identity_type
 
 

--- a/src/eduid_userdb/locked_identity.py
+++ b/src/eduid_userdb/locked_identity.py
@@ -65,17 +65,6 @@ class LockedIdentityNin(LockedIdentityElement, _LockedIdentityNinRequired):
 
     identity_type: str = 'nin'
 
-    @classmethod
-    def data_in_transforms(cls: Type[LockedIdentityNin], data: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Construct locked identity element from a data dict.
-        """
-        data['identity_type'] = 'nin'
-
-        data = super().data_in_transforms(data)
-
-        return data
-
 
 class LockedIdentityList(ElementList):
     """

--- a/src/eduid_userdb/locked_identity.py
+++ b/src/eduid_userdb/locked_identity.py
@@ -36,9 +36,6 @@ class LockedIdentityElement(Element, _LockedIdentityElementRequired):
         """
         :return: Type of identity
         """
-        # XXX this seems wrong: given a list of locked identity elements, we should be able to
-        # XXX find or remove elements through their key, so the key should be unique for
-        # XXX each locked identity element.
         return self.identity_type
 
 

--- a/src/eduid_userdb/locked_identity.py
+++ b/src/eduid_userdb/locked_identity.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from typing import Any, Dict, Type
 
 from eduid_userdb.element import Element, ElementList
@@ -90,9 +90,7 @@ class LockedIdentityList(ElementList):
             else:
                 if item['identity_type'] == 'nin':
                     elements.append(
-                        LockedIdentityNin(
-                            number=item['number'], created_by=item['created_by'], created_ts=item['created_ts']
-                        )
+                        LockedIdentityNin.from_dict(item)
                     )
         ElementList.__init__(self, elements)
 

--- a/src/eduid_userdb/locked_identity.py
+++ b/src/eduid_userdb/locked_identity.py
@@ -11,7 +11,7 @@ __author__ = 'lundberg'
 
 
 @dataclass
-class _LockedIdentityElementRequired(Element):
+class _LockedIdentityElementRequired:
     """
     Required fields for LockedElement, so that they go before the optional
     arguments of Element in the implicit constructor.
@@ -40,7 +40,7 @@ class LockedIdentityElement(Element, _LockedIdentityElementRequired):
 
 
 @dataclass
-class _LockedIdentityNinRequired(LockedIdentityElement):
+class _LockedIdentityNinRequired:
     """
     Required fields for LockedElementNin, so that they go before the optional
     arguments of Element in the implicit constructor.

--- a/src/eduid_userdb/logs/element.py
+++ b/src/eduid_userdb/logs/element.py
@@ -28,8 +28,6 @@ class _LogElementRequired:
 class LogElement(Element, _LogElementRequired):
     """
     """
-    created_ts: datetime = field(default_factory=datetime.utcnow)
-
     name_mapping: ClassVar[Dict[str, str]] = {'eduPersonPrincipalName': 'eppn'}
 
     def validate(self):
@@ -39,13 +37,6 @@ class LogElement(Element, _LogElementRequired):
         # Check that all keys are accounted for and that no string values are blank
         for key in required_keys:
             data = getattr(self, key)
-            if data is None:
-                logger.error(
-                    'Not enough data to log proofing event: {!r}. Required keys: {!r}'.format(
-                        asdict(self), required_keys - self_keys
-                    )
-                )
-                return False
             if isinstance(data, six.string_types):
                 if not data:
                     logger.error('Not enough data to log proofing event: "{}" can not be blank.'.format(key))
@@ -245,7 +236,7 @@ class SeLegProofingFrejaEid(SeLegProofing, _SeLegProofingFrejaEidRequired):
         'user_postal_address': {postal_address_from_navet}
     }
     """
-    vetting_by: str = 'Freja eID',
+    vetting_by: str = 'Freja eID'
 
 
 @dataclass

--- a/src/eduid_userdb/logs/element.py
+++ b/src/eduid_userdb/logs/element.py
@@ -25,6 +25,7 @@ TLogElementSubclass = TypeVar('TLogElementSubclass', bound='LogElement')
 class LogElement(Element):
     """
     """
+
     # Application creating the log element
     created_by: str
 
@@ -71,6 +72,7 @@ class _ProofingLogElementRequired:
     """
     Required fields for ProofingLogElement
     """
+
     # eduPersonPrincipalName
     eppn: str
     # Proofing method version number
@@ -81,6 +83,7 @@ class _ProofingLogElementRequired:
 class ProofingLogElement(LogElement, _ProofingLogElementRequired):
     """
     """
+
     # Proofing method name
     proofing_method: str = ''
 
@@ -90,6 +93,7 @@ class _NinProofingLogElementRequired:
     """
     Required fields for NinProofingLogElement
     """
+
     # National identity number
     nin: str
     # Navet response for users official address
@@ -107,6 +111,7 @@ class _MailAddressProofingRequired:
     """
     Required fields for MailAddressProofing
     """
+
     # e-mail address
     mail_address: str
     # Audit reference to help cross reference audit log and events
@@ -126,6 +131,7 @@ class MailAddressProofing(ProofingLogElement, _MailAddressProofingRequired):
         'reference': 'reference id'
     }
     """
+
     # Proofing method name
     proofing_method: str = 'e-mail'
 
@@ -135,6 +141,7 @@ class _PhoneNumberProofingRequired:
     """
     Required fields for PhoneNumberProofing
     """
+
     # phone number
     phone_number: str
     # Audit reference to help cross reference audit log and events
@@ -154,6 +161,7 @@ class PhoneNumberProofing(ProofingLogElement, _PhoneNumberProofingRequired):
         'reference': 'reference id'
     }
     """
+
     # Proofing method name
     proofing_method: str = 'sms'
 
@@ -163,6 +171,7 @@ class _TeleAdressProofingRequired:
     """
     Required fields for TeleAdressProofing
     """
+
     # Mobile phone number
     mobile_number: str
     # Reason for mobile phone number match to user
@@ -185,6 +194,7 @@ class TeleAdressProofing(NinProofingLogElement, _TeleAdressProofingRequired):
         'user_postal_address': {postal_address_from_navet}
     }
     """
+
     # Proofing method name
     proofing_method: str = 'TeleAdress'
 
@@ -194,6 +204,7 @@ class _TeleAdressProofingRelationRequired:
     """
     Required fields for TeleAdressProofingRelation
     """
+
     # NIN of registered user of mobile phone subscription
     mobile_number_registered_to: str
     # Relation of mobile phone subscriber to User
@@ -221,6 +232,7 @@ class TeleAdressProofingRelation(TeleAdressProofing, _TeleAdressProofingRelation
         'registered_postal_address': {postal_address_from_navet}
     }
     """
+
     # Proofing method name
     proofing_method: str = 'TeleAdress'
 
@@ -230,6 +242,7 @@ class _LetterProofingRequired:
     """
     Required fields for LetterProofing
     """
+
     # Name and address the letter was sent to
     letter_sent_to: str
     # Letter service transaction id
@@ -251,6 +264,7 @@ class LetterProofing(NinProofingLogElement, _LetterProofingRequired):
         'user_postal_address': {postal_address_from_navet}
     }
     """
+
     # Proofing method name
     proofing_method: str = 'letter'
 
@@ -260,6 +274,7 @@ class _SeLegProofingRequired:
     """
     Required fields for SeLegProofing
     """
+
     # Provider transaction id
     transaction_id: str
 
@@ -279,6 +294,7 @@ class SeLegProofing(NinProofingLogElement, _SeLegProofingRequired):
         'user_postal_address': {postal_address_from_navet}
     }
     """
+
     # Proofing method name
     proofing_method: str = 'se-leg'
     # Name of the provider who performed the vetting
@@ -290,6 +306,7 @@ class _SeLegProofingFrejaEidRequired:
     """
     Required fields for SeLegProofingFrejaEid
     """
+
     # Data used to initialize the vetting process
     opaque_data: str
 
@@ -310,6 +327,7 @@ class SeLegProofingFrejaEid(SeLegProofing, _SeLegProofingFrejaEidRequired):
         'user_postal_address': {postal_address_from_navet}
     }
     """
+
     # Name of the provider who performed the vetting
     vetting_by: str = 'Freja eID'
 
@@ -319,6 +337,7 @@ class _OrcidProofingRequired:
     """
     Required fields for OrcidProofing
     """
+
     # Users unique id
     orcid: str
     # OIDC issuer
@@ -341,6 +360,7 @@ class OrcidProofing(ProofingLogElement, _OrcidProofingRequired):
         'proofing_version': '2018v1'
     }
     """
+
     # Proofing method name
     proofing_method: str = 'oidc'
 
@@ -350,6 +370,7 @@ class _SwedenConnectProofingRequired:
     """
     Required fields for SwedenConnectProofing
     """
+
     # Provider transaction id
     issuer: str
     # The authentication context class asserted
@@ -371,6 +392,7 @@ class SwedenConnectProofing(NinProofingLogElement, _SwedenConnectProofingRequire
         'user_postal_address': {postal_address_from_navet}
     }
     """
+
     # Proofing method name
     proofing_method: str = 'swedenconnect'
 
@@ -380,6 +402,7 @@ class _MFATokenProofingRequired:
     """
     Required fields for MFATokenProofing
     """
+
     # Data used to initialize the vetting process
     key_id: str
 
@@ -400,5 +423,6 @@ class MFATokenProofing(SwedenConnectProofing, _MFATokenProofingRequired):
         'user_postal_address': {postal_address_from_navet}
     }
     """
+
     # Proofing method name
     proofing_method: str = 'swedenconnect'

--- a/src/eduid_userdb/logs/element.py
+++ b/src/eduid_userdb/logs/element.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import
 
 from dataclasses import dataclass, field, fields, asdict
 from datetime import datetime
-from typing import Any, ClassVar, Dict
+from typing import ClassVar, Dict
 import logging
 
 import six
@@ -30,7 +30,7 @@ class LogElement(Element, _LogElementRequired):
     """
     created_ts: datetime = field(default_factory=datetime.utcnow)
 
-    name_mapping: ClassVar[Dict[Any, str]] = {'eduPersonPrincipalName': 'eppn'}
+    name_mapping: ClassVar[Dict[str, str]] = {'eduPersonPrincipalName': 'eppn'}
 
     def validate(self):
         element_keys = set([elem.name for elem in fields(Element)])
@@ -221,6 +221,7 @@ class SeLegProofing(NinProofingLogElement, _SeLegProofingRequired):
     }
     """
     proofing_method: str = 'se-leg'
+    vetting_by: str = ''
 
 
 @dataclass

--- a/src/eduid_userdb/logs/element.py
+++ b/src/eduid_userdb/logs/element.py
@@ -203,7 +203,6 @@ class LetterProofing(NinProofingLogElement, _LetterProofingRequired):
 @dataclass
 class _SeLegProofingRequired:
     transaction_id: str
-    vetting_by: str
 
 
 @dataclass

--- a/src/eduid_userdb/logs/element.py
+++ b/src/eduid_userdb/logs/element.py
@@ -55,14 +55,14 @@ class LogElement(Element):
 
         return data
 
-    def _data_out_transforms(self, data: Dict[str, Any], old_userdb_format: bool = False) -> Dict[str, Any]:
+    def _data_out_transforms(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Transform data kept in pythonic format into eduid format.
         """
         if 'eppn' in data:
             data['eduPersonPrincipalName'] = data.pop('eppn')
 
-        data = super()._data_out_transforms(data, old_userdb_format)
+        data = super()._data_out_transforms(data)
 
         return data
 

--- a/src/eduid_userdb/logs/element.py
+++ b/src/eduid_userdb/logs/element.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 class LogElement(Element):
     """
     """
-
+    # Application creating the log element
     created_by: str
 
     name_mapping: ClassVar[Dict[str, str]] = {'eduPersonPrincipalName': 'eppn'}
@@ -47,8 +47,9 @@ class _ProofingLogElementRequired:
     """
     Required fields for ProofingLogElement
     """
-
+    # eduPersonPrincipalName
     eppn: str
+    # Proofing method version number
     proofing_version: str
 
 
@@ -56,7 +57,7 @@ class _ProofingLogElementRequired:
 class ProofingLogElement(LogElement, _ProofingLogElementRequired):
     """
     """
-
+    # Proofing method name
     proofing_method: str = ''
 
 
@@ -65,8 +66,9 @@ class _NinProofingLogElementRequired:
     """
     Required fields for NinProofingLogElement
     """
-
+    # National identity number
     nin: str
+    # Navet response for users official address
     user_postal_address: Dict[str, Any]
 
 
@@ -81,8 +83,9 @@ class _MailAddressProofingRequired:
     """
     Required fields for MailAddressProofing
     """
-
+    # e-mail address
     mail_address: str
+    # Audit reference to help cross reference audit log and events
     reference: str
 
 
@@ -99,7 +102,7 @@ class MailAddressProofing(ProofingLogElement, _MailAddressProofingRequired):
         'reference': 'reference id'
     }
     """
-
+    # Proofing method name
     proofing_method: str = 'e-mail'
 
 
@@ -108,8 +111,9 @@ class _PhoneNumberProofingRequired:
     """
     Required fields for PhoneNumberProofing
     """
-
+    # phone number
     phone_number: str
+    # Audit reference to help cross reference audit log and events
     reference: str
 
 
@@ -126,7 +130,7 @@ class PhoneNumberProofing(ProofingLogElement, _PhoneNumberProofingRequired):
         'reference': 'reference id'
     }
     """
-
+    # Proofing method name
     proofing_method: str = 'sms'
 
 
@@ -135,8 +139,9 @@ class _TeleAdressProofingRequired:
     """
     Required fields for TeleAdressProofing
     """
-
+    # Mobile phone number
     mobile_number: str
+    # Reason for mobile phone number match to user
     reason: str
 
 
@@ -156,7 +161,7 @@ class TeleAdressProofing(NinProofingLogElement, _TeleAdressProofingRequired):
         'user_postal_address': {postal_address_from_navet}
     }
     """
-
+    # Proofing method name
     proofing_method: str = 'TeleAdress'
 
 
@@ -165,9 +170,11 @@ class _TeleAdressProofingRelationRequired:
     """
     Required fields for TeleAdressProofingRelation
     """
-
+    # NIN of registered user of mobile phone subscription
     mobile_number_registered_to: str
+    # Relation of mobile phone subscriber to User
     registered_relation: str
+    # Navet response for mobile phone subscriber
     registered_postal_address: str
 
 
@@ -190,7 +197,7 @@ class TeleAdressProofingRelation(TeleAdressProofing, _TeleAdressProofingRelation
         'registered_postal_address': {postal_address_from_navet}
     }
     """
-
+    # Proofing method name
     proofing_method: str = 'TeleAdress'
 
 
@@ -199,8 +206,9 @@ class _LetterProofingRequired:
     """
     Required fields for LetterProofing
     """
-
+    # Name and address the letter was sent to
     letter_sent_to: str
+    # Letter service transaction id
     transaction_id: str
 
 
@@ -219,7 +227,7 @@ class LetterProofing(NinProofingLogElement, _LetterProofingRequired):
         'user_postal_address': {postal_address_from_navet}
     }
     """
-
+    # Proofing method name
     proofing_method: str = 'letter'
 
 
@@ -228,7 +236,7 @@ class _SeLegProofingRequired:
     """
     Required fields for SeLegProofing
     """
-
+    # Provider transaction id
     transaction_id: str
 
 
@@ -247,8 +255,9 @@ class SeLegProofing(NinProofingLogElement, _SeLegProofingRequired):
         'user_postal_address': {postal_address_from_navet}
     }
     """
-
+    # Proofing method name
     proofing_method: str = 'se-leg'
+    # Name of the provider who performed the vetting
     vetting_by: str = ''
 
 
@@ -257,7 +266,7 @@ class _SeLegProofingFrejaEidRequired:
     """
     Required fields for SeLegProofingFrejaEid
     """
-
+    # Data used to initialize the vetting process
     opaque_data: str
 
 
@@ -277,7 +286,7 @@ class SeLegProofingFrejaEid(SeLegProofing, _SeLegProofingFrejaEidRequired):
         'user_postal_address': {postal_address_from_navet}
     }
     """
-
+    # Name of the provider who performed the vetting
     vetting_by: str = 'Freja eID'
 
 
@@ -286,9 +295,11 @@ class _OrcidProofingRequired:
     """
     Required fields for OrcidProofing
     """
-
+    # Users unique id
     orcid: str
+    # OIDC issuer
     issuer: str
+    # OIDC audience
     audience: str
 
 
@@ -306,7 +317,7 @@ class OrcidProofing(ProofingLogElement, _OrcidProofingRequired):
         'proofing_version': '2018v1'
     }
     """
-
+    # Proofing method name
     proofing_method: str = 'oidc'
 
 
@@ -315,8 +326,9 @@ class _SwedenConnectProofingRequired:
     """
     Required fields for SwedenConnectProofing
     """
-
+    # Provider transaction id
     issuer: str
+    # The authentication context class asserted
     authn_context_class: str
 
 
@@ -335,7 +347,7 @@ class SwedenConnectProofing(NinProofingLogElement, _SwedenConnectProofingRequire
         'user_postal_address': {postal_address_from_navet}
     }
     """
-
+    # Proofing method name
     proofing_method: str = 'swedenconnect'
 
 
@@ -344,7 +356,7 @@ class _MFATokenProofingRequired:
     """
     Required fields for MFATokenProofing
     """
-
+    # Data used to initialize the vetting process
     key_id: str
 
 
@@ -364,5 +376,5 @@ class MFATokenProofing(SwedenConnectProofing, _MFATokenProofingRequired):
         'user_postal_address': {postal_address_from_navet}
     }
     """
-
+    # Proofing method name
     proofing_method: str = 'swedenconnect'

--- a/src/eduid_userdb/logs/element.py
+++ b/src/eduid_userdb/logs/element.py
@@ -6,7 +6,7 @@
 from __future__ import absolute_import
 
 from dataclasses import dataclass, fields
-from typing import ClassVar, Dict
+from typing import Any, ClassVar, Dict
 import logging
 
 import six
@@ -19,17 +19,11 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass
-class _LogElementRequired:
+class LogElement(Element):
     """
-    Required fields for LogElement
     """
     created_by: str
 
-
-@dataclass
-class LogElement(Element, _LogElementRequired):
-    """
-    """
     name_mapping: ClassVar[Dict[str, str]] = {'eduPersonPrincipalName': 'eppn'}
 
     def validate(self) -> bool:
@@ -69,7 +63,7 @@ class _NinProofingLogElementRequired:
     Required fields for NinProofingLogElement
     """
     nin: str
-    user_postal_address: str
+    user_postal_address: Dict[str, Any]
 
 
 @dataclass

--- a/src/eduid_userdb/logs/element.py
+++ b/src/eduid_userdb/logs/element.py
@@ -33,7 +33,8 @@ class LogElement(Element, _LogElementRequired):
     def validate(self):
         element_keys = set([elem.name for elem in fields(Element)])
         self_keys = set([elem.name for elem in fields(self)])
-        required_keys = self_keys - element_keys
+        required_keys = tuple(self_keys - element_keys)
+        required_keys += ('created_ts', 'created_by')
         # Check that all keys are accounted for and that no string values are blank
         for key in required_keys:
             data = getattr(self, key)

--- a/src/eduid_userdb/logs/element.py
+++ b/src/eduid_userdb/logs/element.py
@@ -5,6 +5,8 @@
 
 from __future__ import absolute_import
 
+from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Any, Dict
 import logging
 
@@ -17,95 +19,49 @@ __author__ = 'lundberg'
 logger = logging.getLogger(__name__)
 
 
-class LogElement(Element):
-    def __init__(self, created_by):
-        """
-        :param created_by: Application creating the log element
-
-        :type created_by: six.string_types
-
-        :return: LogElement object
-        :rtype: LogElement
-        """
-        self._required_keys = ['created_by', 'created_ts']
-
-        self._data: Dict[str, Any] = {}
-
-        self.created_by = created_by
-        self.created_ts = True
-
-    def validate(self):
-        # Check that all keys are accounted for and that no string values are blank
-        for key in self._required_keys:
-            data = self._data.get(key)
-            if data is None:
-                logger.error(
-                    'Not enough data to log proofing event: {!r}. Required keys: {!r}'.format(
-                        self._data, list(set(self._required_keys) - set(self._data.keys()))
-                    )
-                )
-                return False
-            if isinstance(data, six.string_types):
-                if not data:
-                    logger.error('Not enough data to log proofing event: "{}" can not be blank.'.format(key))
-                    return False
-        return True
+@dataclass
+class _LogElementRequired:
+    created_by: str
 
 
-class ProofingLogElement(LogElement):
-    def __init__(self, user, created_by, proofing_method, proofing_version):
-        """
-        :param user: User object
-        :param created_by: Application creating the log element
-        :param proofing_method: Proofing method name
-        :param proofing_version: Proofing method version number
-
-        :type user: eduid_userdb.user.User
-        :type created_by: six.string_types
-        :type proofing_method: six.string_types
-        :type proofing_version: six.string_types
-
-        :return: ProofingLogElement object
-        :rtype: ProofingLogElement
-        """
-        super(ProofingLogElement, self).__init__(created_by)
-        self._required_keys.extend(['eduPersonPrincipalName', 'proofing_method', 'proofing_version'])
-        self._data['eduPersonPrincipalName'] = user.eppn
-        self._data['proofing_method'] = proofing_method
-        self._data['proofing_version'] = proofing_version
+@dataclass
+class LogElement(Element, _LogElementRequired):
+    created_ts: datetime = field(default_factory=datetime.utcnow)
 
 
-class NinProofingLogElement(ProofingLogElement):
-    def __init__(self, user, created_by, nin, user_postal_address, proofing_method, proofing_version):
-        """
-        :param user: user object
-        :param created_by: Application creating the log element
-        :param nin: National identity number
-        :param user_postal_address: Navet response for users official address
-        :param proofing_version: Proofing method version number
-
-        :type user: eduid_userdb.User
-        :type created_by: six.string_types
-        :type nin: six.string_types
-        :type user_postal_address: dict
-        :type proofing_version: six.string_types
-
-        :return: NinProofingLogElement object
-        :rtype: NinProofingLogElement
-        """
-        super(NinProofingLogElement, self).__init__(
-            user, created_by, proofing_method=proofing_method, proofing_version=proofing_version
-        )
-        self._required_keys.extend(['nin', 'user_postal_address'])
-        self._data['nin'] = nin
-        self._data['user_postal_address'] = user_postal_address
-
-    @property
-    def user_postal_address(self):
-        return self._data['user_postal_address']
+@dataclass
+class _ProofingLogElementRequired:
+    eppn: str
+    proofing_version: str
 
 
-class MailAddressProofing(ProofingLogElement):
+@dataclass
+class ProofingLogElement(LogElement, _ProofingLogElementRequired):
+    """
+    """
+    proofing_method: str = ''
+
+
+@dataclass
+class _NinProofingLogElementRequired:
+    nin: str
+    user_postal_address: str
+
+
+@dataclass
+class NinProofingLogElement(ProofingLogElement, _NinProofingLogElementRequired):
+    """
+    """
+
+
+@dataclass
+class _MailAddressProofingRequired:
+    mail_address: str
+    reference: str
+
+
+@dataclass
+class MailAddressProofing(ProofingLogElement, _MailAddressProofingRequired):
     """
     {
         'eduPersonPrincipalName': eppn,
@@ -117,33 +73,17 @@ class MailAddressProofing(ProofingLogElement):
         'reference': 'reference id'
     }
     """
-
-    def __init__(self, user, created_by, mail_address, reference, proofing_version):
-        """
-        :param user: User object
-        :param created_by: Application creating the log element
-        :param mail_address: e-mail address
-        :param reference: Audit reference to help cross reference audit log and events
-        :param proofing_version: Proofing method version number
-
-        :type user: eduid_userdb.user.User
-        :type created_by: six.string_types
-        :type mail_address: six.string_types
-        :type reference: six.string_types
-        :type proofing_version: six.string_types
-
-        :return: MailAddressProofing object
-        :rtype: MailAddressProofing
-        """
-        super(MailAddressProofing, self).__init__(
-            user, created_by, proofing_method='e-mail', proofing_version=proofing_version
-        )
-        self._required_keys.extend(['mail_address', 'reference'])
-        self._data['mail_address'] = mail_address
-        self._data['reference'] = reference
+    proofing_method: str = 'e-mail'
 
 
-class PhoneNumberProofing(ProofingLogElement):
+@dataclass
+class _PhoneNumberProofingRequired:
+    phone_number: str
+    reference: str
+
+
+@dataclass
+class PhoneNumberProofing(ProofingLogElement, _PhoneNumberProofingRequired):
     """
     {
         'eduPersonPrincipalName': eppn,
@@ -155,33 +95,17 @@ class PhoneNumberProofing(ProofingLogElement):
         'reference': 'reference id'
     }
     """
-
-    def __init__(self, user, created_by, phone_number, reference, proofing_version):
-        """
-        :param user: User object
-        :param created_by: Application creating the log element
-        :param phone_number: phone number
-        :param reference: Audit reference to help cross reference audit log and events
-        :param proofing_version: Proofing method version number
-
-        :type user: eduid_userdb.user.User
-        :type created_by: six.string_types
-        :type phone_number: six.string_types
-        :type reference: six.string_types
-        :type proofing_version: six.string_types
-
-        :return: PhoneNumberProofing object
-        :rtype: PhoneNumberProofing
-        """
-        super(PhoneNumberProofing, self).__init__(
-            user, created_by, proofing_method='sms', proofing_version=proofing_version
-        )
-        self._required_keys.extend(['phone_number', 'reference'])
-        self._data['phone_number'] = phone_number
-        self._data['reference'] = reference
+    proofing_method: str = 'sms'
 
 
-class TeleAdressProofing(NinProofingLogElement):
+@dataclass
+class _TeleAdressProofingRequired:
+    mobile_number: str
+    reason: str
+
+
+@dataclass
+class TeleAdressProofing(NinProofingLogElement, _TeleAdressProofingRequired):
     """
     {
         'eduPersonPrincipalName': eppn,
@@ -196,37 +120,18 @@ class TeleAdressProofing(NinProofingLogElement):
         'user_postal_address': {postal_address_from_navet}
     }
     """
-
-    def __init__(self, user, created_by, reason, nin, mobile_number, user_postal_address, proofing_version):
-        """
-        :param user: user object
-        :param created_by: Application creating the log element
-        :param reason: Reason for mobile phone number match to user
-        :param nin: National identity number
-        :param mobile_number: Mobile phone number
-        :param user_postal_address: Navet response for users official address
-        :param proofing_version: Proofing method version number
-
-        :type user: eduid_userdb.User
-        :type created_by: six.string_types
-        :type reason: six.string_types
-        :type nin: six.string_types
-        :type mobile_number: six.string_types
-        :type user_postal_address: dict
-        :type proofing_version: six.string_types
-
-        :return: TeleAdressProofing object
-        :rtype: TeleAdressProofing
-        """
-        super(TeleAdressProofing, self).__init__(
-            user, created_by, nin, user_postal_address, proofing_method='TeleAdress', proofing_version=proofing_version
-        )
-        self._required_keys.extend(['reason', 'mobile_number'])
-        self._data['reason'] = reason
-        self._data['mobile_number'] = mobile_number
+    proofing_method: str = 'TeleAdress'
 
 
-class TeleAdressProofingRelation(TeleAdressProofing):
+@dataclass
+class _TeleAdressProofingRelationRequired:
+    mobile_number_registered_to: str
+    registered_relation: str
+    registered_postal_address: str
+
+
+@dataclass
+class TeleAdressProofingRelation(TeleAdressProofing, _TeleAdressProofingRelationRequired):
     """
     {
         'eduPersonPrincipalName': eppn,
@@ -244,56 +149,17 @@ class TeleAdressProofingRelation(TeleAdressProofing):
         'registered_postal_address': {postal_address_from_navet}
     }
     """
-
-    def __init__(
-        self,
-        user,
-        created_by,
-        reason,
-        nin,
-        mobile_number,
-        user_postal_address,
-        mobile_number_registered_to,
-        registered_relation,
-        registered_postal_address,
-        proofing_version,
-    ):
-        """
-        :param user: user object
-        :param created_by: Application creating the log element
-        :param reason: Reason for mobile phone number match to user
-        :param nin: National identity number
-        :param mobile_number: Mobile phone number
-        :param user_postal_address: Navet response for users official address
-        :param mobile_number_registered_to: NIN of registered user of mobile phone subscription
-        :param registered_relation: Relation of mobile phone subscriber to User
-        :param registered_postal_address: Navet response for mobile phone subscriber
-        :param proofing_version: Proofing method version number
-
-        :type user: User
-        :type created_by: six.string_types
-        :type reason: six.string_types
-        :type nin: six.string_types
-        :type mobile_number: six.string_types
-        :type user_postal_address: dict
-        :type mobile_number_registered_to: six.string_types
-        :type registered_relation: six.string_types
-        :type registered_postal_address:  dict
-        :type proofing_version: six.string_types
-
-        :return: TeleAdressProofingRelation object
-        :rtype: TeleAdressProofingRelation
-        """
-        super(TeleAdressProofingRelation, self).__init__(
-            user, created_by, reason, nin, mobile_number, user_postal_address, proofing_version=proofing_version
-        )
-        self._required_keys.extend(['mobile_number_registered_to', 'registered_relation', 'registered_postal_address'])
-        self._data['mobile_number_registered_to'] = mobile_number_registered_to
-        self._data['registered_relation'] = registered_relation
-        self._data['registered_postal_address'] = registered_postal_address
+    proofing_method: str = 'TeleAdress'
 
 
-class LetterProofing(NinProofingLogElement):
+@dataclass
+class _LetterProofingRequired:
+    letter_sent_to: str
+    transaction_id: str
+
+
+@dataclass
+class LetterProofing(NinProofingLogElement, _LetterProofingRequired):
     """
     {
         'eduPersonPrincipalName': eppn,
@@ -307,37 +173,17 @@ class LetterProofing(NinProofingLogElement):
         'user_postal_address': {postal_address_from_navet}
     }
     """
-
-    def __init__(self, user, created_by, nin, letter_sent_to, transaction_id, user_postal_address, proofing_version):
-        """
-        :param user: user object
-        :param created_by: Application creating the log element
-        :param nin: National identity number
-        :param letter_sent_to: Name and address the letter was sent to
-        :param transaction_id: Letter service transaction id
-        :param user_postal_address: Navet response for users official address
-        :param proofing_version: Proofing method version number
-
-        :type user: User
-        :type created_by: six.string_types
-        :type nin: six.string_types
-        :type letter_sent_to: dict
-        :type transaction_id: six.string_types
-        :type user_postal_address: dict
-        :type proofing_version: six.string_types
-
-        :return: LetterProofing object
-        :rtype: LetterProofing
-        """
-        super(LetterProofing, self).__init__(
-            user, created_by, nin, user_postal_address, proofing_method='letter', proofing_version=proofing_version
-        )
-        self._required_keys.extend(['proofing_method', 'letter_sent_to', 'transaction_id'])
-        self._data['letter_sent_to'] = letter_sent_to
-        self._data['transaction_id'] = transaction_id
+    proofing_method: str = 'letter'
 
 
-class SeLegProofing(NinProofingLogElement):
+@dataclass
+class _SeLegProofingRequired:
+    vetting_by: str
+    transaction_id: str
+
+
+@dataclass
+class SeLegProofing(NinProofingLogElement, _SeLegProofingRequired):
     """
     {
         'eduPersonPrincipalName': eppn,
@@ -351,37 +197,16 @@ class SeLegProofing(NinProofingLogElement):
         'user_postal_address': {postal_address_from_navet}
     }
     """
-
-    def __init__(self, user, created_by, nin, vetting_by, transaction_id, user_postal_address, proofing_version):
-        """
-        :param user: user object
-        :param created_by: Application creating the log element
-        :param nin: National identity number
-        :param vetting_by: Name of the provider who performed the vetting
-        :param transaction_id: Provider transaction id
-        :param user_postal_address: Navet response for users official address
-        :param proofing_version: Proofing method version number
-
-        :type user: User
-        :type created_by: six.string_types
-        :type nin: six.string_types
-        :type vetting_by: six.string_types
-        :type transaction_id: six.string_types
-        :type user_postal_address: dict
-        :type proofing_version: six.string_types
-
-        :return: SeLegProofing object
-        :rtype: SeLegProofing
-        """
-        super(SeLegProofing, self).__init__(
-            user, created_by, nin, user_postal_address, proofing_method='se-leg', proofing_version=proofing_version
-        )
-        self._required_keys.extend(['proofing_method', 'vetting_by', 'transaction_id'])
-        self._data['vetting_by'] = vetting_by
-        self._data['transaction_id'] = transaction_id
+    proofing_method: str = 'se-leg'
 
 
-class SeLegProofingFrejaEid(SeLegProofing):
+@dataclass
+class _SeLegProofingFrejaEidRequired:
+    opaque_data: str
+
+
+@dataclass
+class SeLegProofingFrejaEid(SeLegProofing, _SeLegProofingFrejaEidRequired):
     """
     {
         'eduPersonPrincipalName': eppn,
@@ -396,42 +221,16 @@ class SeLegProofingFrejaEid(SeLegProofing):
         'user_postal_address': {postal_address_from_navet}
     }
     """
-
-    def __init__(self, user, created_by, nin, transaction_id, opaque_data, user_postal_address, proofing_version):
-        """
-        :param user: user object
-        :param created_by: Application creating the log element
-        :param nin: National identity number
-        :param transaction_id: Provider transaction id
-        :param opaque_data: Data used to initialize the vetting process
-        :param user_postal_address: Navet response for users official address
-        :param proofing_version: Proofing method version number
-
-        :type user: User
-        :type created_by: six.string_types
-        :type nin: six.string_types
-        :type transaction_id: six.string_types
-        :type opaque_data: six.string_types
-        :type user_postal_address: dict
-        :type proofing_version: six.string_types
-
-        :return: SeLegProofingFrejaEid object
-        :rtype: SeLegProofingFrejaEid
-        """
-        super(SeLegProofingFrejaEid, self).__init__(
-            user,
-            created_by,
-            nin,
-            vetting_by='Freja eID',
-            transaction_id=transaction_id,
-            user_postal_address=user_postal_address,
-            proofing_version=proofing_version,
-        )
-        self._required_keys.extend(['opaque_data'])
-        self._data['opaque_data'] = opaque_data
+    proofing_method: str = 'se-leg'
 
 
-class OrcidProofing(ProofingLogElement):
+@dataclass
+class _OrcidProofingRequired:
+    opaque_data: str
+
+
+@dataclass
+class OrcidProofing(ProofingLogElement, _OrcidProofingRequired):
     """
     {
         'eduPersonPrincipalName': eppn,
@@ -444,38 +243,17 @@ class OrcidProofing(ProofingLogElement):
         'proofing_version': '2018v1'
     }
     """
-
-    def __init__(self, user, created_by, orcid, issuer, audience, proofing_method, proofing_version):
-        """
-        :param user: User object
-        :param created_by: Application creating the log element
-        :param orcid: Users unique id
-        :param issuer: OIDC issuer
-        :param audience: OIDC audience
-        :param proofing_method: Proofing method name
-        :param proofing_version: Proofing method version number
-
-        :type user: eduid_userdb.user.User
-        :type created_by: six.string_types
-        :type orcid: six.string_types
-        :type issuer: six.string_types
-        :type audience: list
-        :type proofing_method: six.string_types
-        :type proofing_version: six.string_types
-
-        :return: ProofingLogElement object
-        :rtype: ProofingLogElement
-        """
-        super(OrcidProofing, self).__init__(
-            user, created_by, proofing_method=proofing_method, proofing_version=proofing_version
-        )
-        self._required_keys.extend(['orcid', 'issuer', 'audience'])
-        self._data['orcid'] = orcid
-        self._data['issuer'] = issuer
-        self._data['audience'] = audience
+    proofing_method: str = 'oidc'
 
 
-class SwedenConnectProofing(NinProofingLogElement):
+@dataclass
+class _SwedenConnectProofingRequired:
+    issuer: str
+    authn_context_class: str
+
+
+@dataclass
+class SwedenConnectProofing(NinProofingLogElement, _SwedenConnectProofingRequired):
     """
     {
         'eduPersonPrincipalName': eppn,
@@ -489,42 +267,16 @@ class SwedenConnectProofing(NinProofingLogElement):
         'user_postal_address': {postal_address_from_navet}
     }
     """
-
-    def __init__(self, user, created_by, nin, issuer, authn_context_class, user_postal_address, proofing_version):
-        """
-        :param user: user object
-        :param created_by: Application creating the log element
-        :param nin: National identity number
-        :param issuer: Provider transaction id
-        :param authn_context_class: The authentication context class asserted
-        :param user_postal_address: Navet response for users official address
-        :param proofing_version: Proofing method version number
-
-        :type user: User
-        :type created_by: six.string_types
-        :type nin: six.string_types
-        :type issuer: six.string_types
-        :type authn_context_class: six.string_types
-        :type user_postal_address: dict
-        :type proofing_version: six.string_types
-
-        :return: SwedenConnectProofing object
-        :rtype: SwedenConnectProofing
-        """
-        super(SwedenConnectProofing, self).__init__(
-            user,
-            created_by,
-            nin,
-            user_postal_address,
-            proofing_method='swedenconnect',
-            proofing_version=proofing_version,
-        )
-        self._required_keys.extend(['issuer', 'authn_context_class'])
-        self._data['issuer'] = issuer
-        self._data['authn_context_class'] = authn_context_class
+    proofing_method: str = 'swedenconnect'
 
 
-class MFATokenProofing(SwedenConnectProofing):
+@dataclass
+class _MFATokenProofingRequired:
+    key_id: str
+
+
+@dataclass
+class MFATokenProofing(SwedenConnectProofing, _MFATokenProofingRequired):
     """
     {
         'eduPersonPrincipalName': eppn,
@@ -539,34 +291,4 @@ class MFATokenProofing(SwedenConnectProofing):
         'user_postal_address': {postal_address_from_navet}
     }
     """
-
-    def __init__(
-        self, user, created_by, nin, issuer, authn_context_class, key_id, user_postal_address, proofing_version
-    ):
-        """
-        :param user: user object
-        :param created_by: Application creating the log element
-        :param nin: National identity number
-        :param issuer: Provider transaction id
-        :param authn_context_class: The authentication context class asserted
-        :param key_id: Data used to initialize the vetting process
-        :param user_postal_address: Navet response for users official address
-        :param proofing_version: Proofing method version number
-
-        :type user: User
-        :type created_by: six.string_types
-        :type nin: six.string_types
-        :type issuer: six.string_types
-        :type authn_context_class: six.string_types
-        :type key_id: six.string_types
-        :type user_postal_address: dict
-        :type proofing_version: six.string_types
-
-        :return: MFATokenProofing object
-        :rtype: MFATokenProofing
-        """
-        super(MFATokenProofing, self).__init__(
-            user, created_by, nin, issuer, authn_context_class, user_postal_address, proofing_version=proofing_version
-        )
-        self._required_keys.extend(['key_id'])
-        self._data['key_id'] = key_id
+    proofing_method: str = 'swedenconnect'

--- a/src/eduid_userdb/logs/element.py
+++ b/src/eduid_userdb/logs/element.py
@@ -5,9 +5,9 @@
 
 from __future__ import absolute_import
 
+import logging
 from dataclasses import dataclass, fields
 from typing import Any, ClassVar, Dict
-import logging
 
 import six
 
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 class LogElement(Element):
     """
     """
+
     created_by: str
 
     name_mapping: ClassVar[Dict[str, str]] = {'eduPersonPrincipalName': 'eppn'}
@@ -46,6 +47,7 @@ class _ProofingLogElementRequired:
     """
     Required fields for ProofingLogElement
     """
+
     eppn: str
     proofing_version: str
 
@@ -54,6 +56,7 @@ class _ProofingLogElementRequired:
 class ProofingLogElement(LogElement, _ProofingLogElementRequired):
     """
     """
+
     proofing_method: str = ''
 
 
@@ -62,6 +65,7 @@ class _NinProofingLogElementRequired:
     """
     Required fields for NinProofingLogElement
     """
+
     nin: str
     user_postal_address: Dict[str, Any]
 
@@ -77,6 +81,7 @@ class _MailAddressProofingRequired:
     """
     Required fields for MailAddressProofing
     """
+
     mail_address: str
     reference: str
 
@@ -94,6 +99,7 @@ class MailAddressProofing(ProofingLogElement, _MailAddressProofingRequired):
         'reference': 'reference id'
     }
     """
+
     proofing_method: str = 'e-mail'
 
 
@@ -102,6 +108,7 @@ class _PhoneNumberProofingRequired:
     """
     Required fields for PhoneNumberProofing
     """
+
     phone_number: str
     reference: str
 
@@ -119,6 +126,7 @@ class PhoneNumberProofing(ProofingLogElement, _PhoneNumberProofingRequired):
         'reference': 'reference id'
     }
     """
+
     proofing_method: str = 'sms'
 
 
@@ -127,6 +135,7 @@ class _TeleAdressProofingRequired:
     """
     Required fields for TeleAdressProofing
     """
+
     mobile_number: str
     reason: str
 
@@ -147,6 +156,7 @@ class TeleAdressProofing(NinProofingLogElement, _TeleAdressProofingRequired):
         'user_postal_address': {postal_address_from_navet}
     }
     """
+
     proofing_method: str = 'TeleAdress'
 
 
@@ -155,6 +165,7 @@ class _TeleAdressProofingRelationRequired:
     """
     Required fields for TeleAdressProofingRelation
     """
+
     mobile_number_registered_to: str
     registered_relation: str
     registered_postal_address: str
@@ -179,6 +190,7 @@ class TeleAdressProofingRelation(TeleAdressProofing, _TeleAdressProofingRelation
         'registered_postal_address': {postal_address_from_navet}
     }
     """
+
     proofing_method: str = 'TeleAdress'
 
 
@@ -187,6 +199,7 @@ class _LetterProofingRequired:
     """
     Required fields for LetterProofing
     """
+
     letter_sent_to: str
     transaction_id: str
 
@@ -206,6 +219,7 @@ class LetterProofing(NinProofingLogElement, _LetterProofingRequired):
         'user_postal_address': {postal_address_from_navet}
     }
     """
+
     proofing_method: str = 'letter'
 
 
@@ -214,6 +228,7 @@ class _SeLegProofingRequired:
     """
     Required fields for SeLegProofing
     """
+
     transaction_id: str
 
 
@@ -232,6 +247,7 @@ class SeLegProofing(NinProofingLogElement, _SeLegProofingRequired):
         'user_postal_address': {postal_address_from_navet}
     }
     """
+
     proofing_method: str = 'se-leg'
     vetting_by: str = ''
 
@@ -241,6 +257,7 @@ class _SeLegProofingFrejaEidRequired:
     """
     Required fields for SeLegProofingFrejaEid
     """
+
     opaque_data: str
 
 
@@ -260,6 +277,7 @@ class SeLegProofingFrejaEid(SeLegProofing, _SeLegProofingFrejaEidRequired):
         'user_postal_address': {postal_address_from_navet}
     }
     """
+
     vetting_by: str = 'Freja eID'
 
 
@@ -268,6 +286,7 @@ class _OrcidProofingRequired:
     """
     Required fields for OrcidProofing
     """
+
     orcid: str
     issuer: str
     audience: str
@@ -287,6 +306,7 @@ class OrcidProofing(ProofingLogElement, _OrcidProofingRequired):
         'proofing_version': '2018v1'
     }
     """
+
     proofing_method: str = 'oidc'
 
 
@@ -295,6 +315,7 @@ class _SwedenConnectProofingRequired:
     """
     Required fields for SwedenConnectProofing
     """
+
     issuer: str
     authn_context_class: str
 
@@ -314,6 +335,7 @@ class SwedenConnectProofing(NinProofingLogElement, _SwedenConnectProofingRequire
         'user_postal_address': {postal_address_from_navet}
     }
     """
+
     proofing_method: str = 'swedenconnect'
 
 
@@ -322,6 +344,7 @@ class _MFATokenProofingRequired:
     """
     Required fields for MFATokenProofing
     """
+
     key_id: str
 
 
@@ -341,4 +364,5 @@ class MFATokenProofing(SwedenConnectProofing, _MFATokenProofingRequired):
         'user_postal_address': {postal_address_from_navet}
     }
     """
+
     proofing_method: str = 'swedenconnect'

--- a/src/eduid_userdb/logs/element.py
+++ b/src/eduid_userdb/logs/element.py
@@ -44,25 +44,25 @@ class LogElement(Element):
         return True
 
     @classmethod
-    def _data_in_transforms(cls: Type[TLogElementSubclass], data: Dict[str, Any]) -> Dict[str, Any]:
+    def _from_dict_transform(cls: Type[TLogElementSubclass], data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Transform data received in eduid format into pythonic format.
         """
-        data = super()._data_in_transforms(data)
+        data = super()._from_dict_transform(data)
 
         if 'eduPersonPrincipalName' in data:
             data['eppn'] = data.pop('eduPersonPrincipalName')
 
         return data
 
-    def _data_out_transforms(self, data: Dict[str, Any]) -> Dict[str, Any]:
+    def _to_dict_transform(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Transform data kept in pythonic format into eduid format.
         """
         if 'eppn' in data:
             data['eduPersonPrincipalName'] = data.pop('eppn')
 
-        data = super()._data_out_transforms(data)
+        data = super()._to_dict_transform(data)
 
         return data
 

--- a/src/eduid_userdb/logs/element.py
+++ b/src/eduid_userdb/logs/element.py
@@ -5,8 +5,7 @@
 
 from __future__ import absolute_import
 
-from dataclasses import dataclass, field, fields, asdict
-from datetime import datetime
+from dataclasses import dataclass, fields
 from typing import ClassVar, Dict
 import logging
 
@@ -21,6 +20,9 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class _LogElementRequired:
+    """
+    Required fields for LogElement
+    """
     created_by: str
 
 
@@ -30,7 +32,7 @@ class LogElement(Element, _LogElementRequired):
     """
     name_mapping: ClassVar[Dict[str, str]] = {'eduPersonPrincipalName': 'eppn'}
 
-    def validate(self):
+    def validate(self) -> bool:
         element_keys = set([elem.name for elem in fields(Element)])
         self_keys = set([elem.name for elem in fields(self)])
         required_keys = tuple(self_keys - element_keys)
@@ -47,6 +49,9 @@ class LogElement(Element, _LogElementRequired):
 
 @dataclass
 class _ProofingLogElementRequired:
+    """
+    Required fields for ProofingLogElement
+    """
     eppn: str
     proofing_version: str
 
@@ -60,6 +65,9 @@ class ProofingLogElement(LogElement, _ProofingLogElementRequired):
 
 @dataclass
 class _NinProofingLogElementRequired:
+    """
+    Required fields for NinProofingLogElement
+    """
     nin: str
     user_postal_address: str
 
@@ -72,6 +80,9 @@ class NinProofingLogElement(ProofingLogElement, _NinProofingLogElementRequired):
 
 @dataclass
 class _MailAddressProofingRequired:
+    """
+    Required fields for MailAddressProofing
+    """
     mail_address: str
     reference: str
 
@@ -94,6 +105,9 @@ class MailAddressProofing(ProofingLogElement, _MailAddressProofingRequired):
 
 @dataclass
 class _PhoneNumberProofingRequired:
+    """
+    Required fields for PhoneNumberProofing
+    """
     phone_number: str
     reference: str
 
@@ -116,6 +130,9 @@ class PhoneNumberProofing(ProofingLogElement, _PhoneNumberProofingRequired):
 
 @dataclass
 class _TeleAdressProofingRequired:
+    """
+    Required fields for TeleAdressProofing
+    """
     mobile_number: str
     reason: str
 
@@ -141,6 +158,9 @@ class TeleAdressProofing(NinProofingLogElement, _TeleAdressProofingRequired):
 
 @dataclass
 class _TeleAdressProofingRelationRequired:
+    """
+    Required fields for TeleAdressProofingRelation
+    """
     mobile_number_registered_to: str
     registered_relation: str
     registered_postal_address: str
@@ -170,6 +190,9 @@ class TeleAdressProofingRelation(TeleAdressProofing, _TeleAdressProofingRelation
 
 @dataclass
 class _LetterProofingRequired:
+    """
+    Required fields for LetterProofing
+    """
     letter_sent_to: str
     transaction_id: str
 
@@ -194,6 +217,9 @@ class LetterProofing(NinProofingLogElement, _LetterProofingRequired):
 
 @dataclass
 class _SeLegProofingRequired:
+    """
+    Required fields for SeLegProofing
+    """
     transaction_id: str
 
 
@@ -218,6 +244,9 @@ class SeLegProofing(NinProofingLogElement, _SeLegProofingRequired):
 
 @dataclass
 class _SeLegProofingFrejaEidRequired:
+    """
+    Required fields for SeLegProofingFrejaEid
+    """
     opaque_data: str
 
 
@@ -242,6 +271,9 @@ class SeLegProofingFrejaEid(SeLegProofing, _SeLegProofingFrejaEidRequired):
 
 @dataclass
 class _OrcidProofingRequired:
+    """
+    Required fields for OrcidProofing
+    """
     orcid: str
     issuer: str
     audience: str
@@ -266,6 +298,9 @@ class OrcidProofing(ProofingLogElement, _OrcidProofingRequired):
 
 @dataclass
 class _SwedenConnectProofingRequired:
+    """
+    Required fields for SwedenConnectProofing
+    """
     issuer: str
     authn_context_class: str
 
@@ -290,6 +325,9 @@ class SwedenConnectProofing(NinProofingLogElement, _SwedenConnectProofingRequire
 
 @dataclass
 class _MFATokenProofingRequired:
+    """
+    Required fields for MFATokenProofing
+    """
     key_id: str
 
 

--- a/src/eduid_userdb/mail.py
+++ b/src/eduid_userdb/mail.py
@@ -33,12 +33,10 @@
 #
 from __future__ import annotations
 
-import copy
 from dataclasses import dataclass, asdict
 from typing import Any, Dict, Optional, Type
 
 from eduid_userdb.element import PrimaryElement, PrimaryElementList
-from eduid_userdb.exceptions import UserDBValueError
 
 __author__ = 'ft'
 
@@ -54,40 +52,9 @@ class MailAddress(PrimaryElement):
     """
     email: Optional[str] = None
 
-    @classmethod
-    def massage_data(cls: Type[MailAddress], data: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        """
-        data = super().massage_data(data)
+    name_mapping = {'added_timestamp': 'created_ts', 'csrf': ''}
+    old_names = ('added_timestamp',)
 
-        if 'added_timestamp' in data:
-            # old userdb-style creation timestamp
-            data['created_ts'] = data.pop('added_timestamp')
-
-        # CSRF tokens were accidentally put in the database some time ago
-        if 'csrf' in data:
-            del data['csrf']
-
-        return data
-
-    def to_dict(self, old_userdb_format=False):
-        """
-        Convert Element to a dict, that can be used to reconstruct the
-        Element later.
-
-        :param old_userdb_format: Set to True to get data back in legacy format.
-        :type old_userdb_format: bool
-        """
-        data = asdict(self)
-        if old_userdb_format:
-            # XXX created_ts -> added_timestamp
-            if 'created_ts' in data:
-                data['added_timestamp'] = data.pop('created_ts')
-            del data['primary']
-
-        return data
-
-    # -----------------------------------------------------------------
     @property
     def key(self):
         """

--- a/src/eduid_userdb/mail.py
+++ b/src/eduid_userdb/mail.py
@@ -33,8 +33,8 @@
 #
 from __future__ import annotations
 
-from dataclasses import dataclass, asdict
-from typing import Any, Dict, Optional, Type
+from dataclasses import dataclass
+from typing import ClassVar, Dict, Optional
 
 from eduid_userdb.element import PrimaryElement, PrimaryElementList
 
@@ -52,7 +52,7 @@ class MailAddress(PrimaryElement):
     """
     email: Optional[str] = None
 
-    name_mapping = {'added_timestamp': 'created_ts', 'csrf': ''}
+    name_mapping: ClassVar[Dict[str, str]] = {'added_timestamp': 'created_ts', 'csrf': ''}
     old_names = ('added_timestamp',)
 
     @property

--- a/src/eduid_userdb/mail.py
+++ b/src/eduid_userdb/mail.py
@@ -44,11 +44,6 @@ __author__ = 'ft'
 @dataclass
 class MailAddress(PrimaryElement):
     """
-    :param data: Mail address parameters from database
-    :param raise_on_unknown: Raise exception on unknown values in `data' or not.
-
-    :type data: dict
-    :type raise_on_unknown: bool
     """
     email: Optional[str] = None
 
@@ -56,7 +51,7 @@ class MailAddress(PrimaryElement):
     old_names = ('added_timestamp',)
 
     @property
-    def key(self):
+    def key(self) -> str:
         """
         Return the element that is used as key for e-mail addresses in a PrimaryElementList.
         """

--- a/src/eduid_userdb/mail.py
+++ b/src/eduid_userdb/mail.py
@@ -51,7 +51,7 @@ class MailAddress(PrimaryElement):
     old_names = ('added_timestamp',)
 
     @property
-    def key(self) -> str:
+    def key(self) -> Optional[str]:
         """
         Return the element that is used as key for e-mail addresses in a PrimaryElementList.
         """

--- a/src/eduid_userdb/mail.py
+++ b/src/eduid_userdb/mail.py
@@ -35,10 +35,7 @@ from __future__ import annotations
 
 import copy
 from dataclasses import dataclass, asdict
-from datetime import datetime
-from typing import Any, Dict, Optional, Type, Union
-
-from six import string_types
+from typing import Any, Dict, Optional, Type
 
 from eduid_userdb.element import PrimaryElement, PrimaryElementList
 from eduid_userdb.exceptions import UserDBValueError
@@ -58,15 +55,10 @@ class MailAddress(PrimaryElement):
     email: Optional[str] = None
 
     @classmethod
-    def from_dict(
-        cls: Type[MailAddress], data: Dict[str, Any], raise_on_unknown: bool = True, ignore_data: Optional[Dict[str, Any]] = None
-    ) -> MailAddress:
-
-        data_in = data
-        data = copy.copy(data_in)  # to not modify callers data
-
-        if not isinstance(data, dict):
-            raise UserDBValueError("Invalid 'data', not dict ({!r})".format(type(data)))
+    def massage_data(cls: Type[MailAddress], data: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        """
+        data = super().massage_data(data)
 
         if 'added_timestamp' in data:
             # old userdb-style creation timestamp
@@ -76,13 +68,7 @@ class MailAddress(PrimaryElement):
         if 'csrf' in data:
             del data['csrf']
 
-        email = data.pop('email')
-
-        self = super().from_dict(data, raise_on_unknown=raise_on_unknown, ignore_data=ignore_data)
-
-        self.email = email
-
-        return self
+        return data
 
     def to_dict(self, old_userdb_format=False):
         """
@@ -122,14 +108,14 @@ class MailAddressList(PrimaryElementList):
     :type addresses: [dict | MailAddress]
     """
 
-    def __init__(self, addresses, raise_on_unknown=True):
+    def __init__(self, addresses):
         elements = []
 
         for this in addresses:
             if isinstance(this, MailAddress):
                 address = this
             else:
-                address = address_from_dict(this, raise_on_unknown)
+                address = address_from_dict(this)
             elements.append(address)
 
         PrimaryElementList.__init__(self, elements)
@@ -173,7 +159,7 @@ class MailAddressList(PrimaryElementList):
         return PrimaryElementList.find(self, email)
 
 
-def address_from_dict(data, raise_on_unknown=True):
+def address_from_dict(data):
     """
     Create a MailAddress instance from a dict.
 
@@ -184,4 +170,4 @@ def address_from_dict(data, raise_on_unknown=True):
     :type raise_on_unknown: bool
     :rtype: MailAddress
     """
-    return MailAddress.from_dict(data, raise_on_unknown=raise_on_unknown)
+    return MailAddress.from_dict(data)

--- a/src/eduid_userdb/mail.py
+++ b/src/eduid_userdb/mail.py
@@ -34,6 +34,7 @@
 from __future__ import annotations
 
 import copy
+from dataclasses import dataclass, asdict
 from datetime import datetime
 from typing import Any, Dict, Optional, Type, Union
 
@@ -45,6 +46,7 @@ from eduid_userdb.exceptions import UserDBValueError
 __author__ = 'ft'
 
 
+@dataclass
 class MailAddress(PrimaryElement):
     """
     :param data: Mail address parameters from database
@@ -53,19 +55,7 @@ class MailAddress(PrimaryElement):
     :type data: dict
     :type raise_on_unknown: bool
     """
-
-    def __init__(
-        self,
-        email: Optional[str] = None,
-        application: Optional[str] = None,
-        verified: bool = False,
-        created_ts: Optional[Union[datetime, bool]] = None,
-        primary: bool = False,
-        data: Optional[Dict[str, Any]] = None,
-        raise_on_unknown: bool = True,
-        called_directly: bool = True,
-    ):
-        raise NotImplementedError()
+    email: Optional[str] = None
 
     @classmethod
     def from_dict(
@@ -94,36 +84,6 @@ class MailAddress(PrimaryElement):
 
         return self
 
-    # -----------------------------------------------------------------
-    @property
-    def key(self):
-        """
-        Return the element that is used as key for e-mail addresses in a PrimaryElementList.
-        """
-        return self.email
-
-    # -----------------------------------------------------------------
-    @property
-    def email(self):
-        """
-        This is the e-mail address.
-
-        :return: E-mail address.
-        :rtype: str
-        """
-        return self._data['email']
-
-    @email.setter
-    def email(self, value):
-        """
-        :param value: e-mail address.
-        :type value: str | unicode
-        """
-        if not isinstance(value, string_types):
-            raise UserDBValueError("Invalid 'email': {!r}".format(value))
-        self._data['email'] = str(value.lower())
-
-    # -----------------------------------------------------------------
     def to_dict(self, old_userdb_format=False):
         """
         Convert Element to a dict, that can be used to reconstruct the
@@ -132,14 +92,22 @@ class MailAddress(PrimaryElement):
         :param old_userdb_format: Set to True to get data back in legacy format.
         :type old_userdb_format: bool
         """
-        if not old_userdb_format:
-            return self._data
-        old = copy.copy(self._data)
-        # XXX created_ts -> added_timestamp
-        if 'created_ts' in old:
-            old['added_timestamp'] = old.pop('created_ts')
-        del old['primary']
-        return old
+        data = asdict(self)
+        if old_userdb_format:
+            # XXX created_ts -> added_timestamp
+            if 'created_ts' in data:
+                data['added_timestamp'] = data.pop('created_ts')
+            del data['primary']
+
+        return data
+
+    # -----------------------------------------------------------------
+    @property
+    def key(self):
+        """
+        Return the element that is used as key for e-mail addresses in a PrimaryElementList.
+        """
+        return self.email
 
 
 class MailAddressList(PrimaryElementList):

--- a/src/eduid_userdb/mail.py
+++ b/src/eduid_userdb/mail.py
@@ -52,7 +52,7 @@ class MailAddress(PrimaryElement):
     """
     email: Optional[str] = None
 
-    name_mapping: ClassVar[Dict[str, str]] = {'added_timestamp': 'created_ts', 'csrf': ''}
+    name_mapping: ClassVar[Dict[str, str]] = {'added_timestamp': 'created_ts', 'application': 'created_by', 'csrf': ''}
     old_names = ('added_timestamp',)
 
     @property

--- a/src/eduid_userdb/mail.py
+++ b/src/eduid_userdb/mail.py
@@ -45,6 +45,7 @@ __author__ = 'ft'
 class MailAddress(PrimaryElement):
     """
     """
+
     email: Optional[str] = None
 
     name_mapping: ClassVar[Dict[str, str]] = {'added_timestamp': 'created_ts', 'application': 'created_by', 'csrf': ''}

--- a/src/eduid_userdb/mail.py
+++ b/src/eduid_userdb/mail.py
@@ -70,21 +70,6 @@ class MailAddress(PrimaryElement):
 
         return data
 
-    def _data_out_transforms(self, data: Dict[str, Any], old_userdb_format: bool = False) -> Dict[str, Any]:
-        """
-        Transform data kept in pythonic format into eduid format.
-        """
-        if 'created_by' in data:
-            data['application'] = data.pop('created_by')
-
-        if old_userdb_format:
-            if 'created_ts' in data:
-                data['added_timestamp'] = data.pop('created_ts')
-
-        data = super()._data_out_transforms(data, old_userdb_format)
-
-        return data
-
 
 class MailAddressList(PrimaryElementList):
     """

--- a/src/eduid_userdb/mail.py
+++ b/src/eduid_userdb/mail.py
@@ -56,11 +56,11 @@ class MailAddress(PrimaryElement):
         return self.email
 
     @classmethod
-    def _data_in_transforms(cls: Type[MailAddress], data: Dict[str, Any]) -> Dict[str, Any]:
+    def _from_dict_transform(cls: Type[MailAddress], data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Transform data received in eduid format into pythonic format.
         """
-        data = super()._data_in_transforms(data)
+        data = super()._from_dict_transform(data)
 
         if 'added_timestamp' in data:
             data['created_ts'] = data.pop('added_timestamp')

--- a/src/eduid_userdb/nin.py
+++ b/src/eduid_userdb/nin.py
@@ -45,6 +45,7 @@ __author__ = 'ft'
 class Nin(PrimaryElement):
     """
     """
+
     number: Optional[str] = None
 
     name_mapping: ClassVar[Dict[str, str]] = {'application': 'created_by'}

--- a/src/eduid_userdb/nin.py
+++ b/src/eduid_userdb/nin.py
@@ -34,7 +34,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import Any, ClassVar, Dict, Optional
 
 from eduid_userdb.element import PrimaryElement, PrimaryElementList
 
@@ -46,6 +46,8 @@ class Nin(PrimaryElement):
     """
     """
     number: Optional[str] = None
+
+    name_mapping: ClassVar[Dict[str, str]] = {'application': 'created_by'}
 
     @property
     def key(self):

--- a/src/eduid_userdb/nin.py
+++ b/src/eduid_userdb/nin.py
@@ -50,7 +50,7 @@ class Nin(PrimaryElement):
     name_mapping: ClassVar[Dict[str, str]] = {'application': 'created_by'}
 
     @property
-    def key(self) -> str:
+    def key(self) -> Optional[str]:
         """
         Return the element that is used as key for nin numberes in a PrimaryElementList.
         """

--- a/src/eduid_userdb/nin.py
+++ b/src/eduid_userdb/nin.py
@@ -50,7 +50,7 @@ class Nin(PrimaryElement):
     name_mapping: ClassVar[Dict[str, str]] = {'application': 'created_by'}
 
     @property
-    def key(self):
+    def key(self) -> str:
         """
         Return the element that is used as key for nin numberes in a PrimaryElementList.
         """

--- a/src/eduid_userdb/nin.py
+++ b/src/eduid_userdb/nin.py
@@ -33,102 +33,26 @@
 #
 from __future__ import annotations
 
-import copy
-from datetime import datetime
-from typing import Any, Dict, Optional, Type, Union
-
-from six import string_types
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
 
 from eduid_userdb.element import PrimaryElement, PrimaryElementList
-from eduid_userdb.exceptions import UserDBValueError
 
 __author__ = 'ft'
 
 
+@dataclass
 class Nin(PrimaryElement):
     """
-    :param data: Phone number parameters from database
-    :param raise_on_unknown: Raise exception on unknown values in `data' or not.
-
-    :type data: dict
-    :type raise_on_unknown: bool
     """
+    number: Optional[str] = None
 
-    def __init__(
-        self,
-        number: Optional[str] = None,
-        application: Optional[str] = None,
-        verified: bool = False,
-        created_ts: Optional[Union[datetime, bool]] = None,
-        primary: bool = False,
-        data: Optional[Dict[str, Any]] = None,
-        raise_on_unknown: bool = True,
-        called_directly: bool = True,
-    ):
-        raise NotImplementedError()
-
-    @classmethod
-    def from_dict(
-        cls: Type[Nin], data: Dict[str, Any], raise_on_unknown: bool = True, ignore_data: Optional[Dict[str, Any]] = None
-    ) -> Nin:
-        data_in = data
-        data = copy.copy(data_in)  # to not modify callers data
-
-        if not isinstance(data, dict):
-            raise UserDBValueError("Invalid 'data', not dict ({!r})".format(type(data)))
-
-        if 'created_ts' not in data:
-            data['created_ts'] = True
-
-        number = data.pop('number')
-
-        self = super().from_dict(data, raise_on_unknown)
-        self.number = number
-
-        return self
-
-    # -----------------------------------------------------------------
     @property
     def key(self):
         """
         Return the element that is used as key for nin numberes in a PrimaryElementList.
         """
         return self.number
-
-    # -----------------------------------------------------------------
-    @property
-    def number(self):
-        """
-        This is the nin number.
-
-        :return: nin number.
-        :rtype: str | unicode
-        """
-        return self._data['number']
-
-    @number.setter
-    def number(self, value):
-        """
-        :param value: nin number.
-        :type value: str | unicode
-        """
-        if not isinstance(value, string_types):
-            raise UserDBValueError("Invalid 'number': {!r}".format(value))
-        self._data['number'] = str(value.lower())
-
-    # -----------------------------------------------------------------
-    def to_dict(self, old_userdb_format=False):
-        """
-        Convert Element to a dict, that can be used to reconstruct the
-        Element later.
-
-        :param old_userdb_format: Set to True to get data back in legacy format.
-        :type old_userdb_format: bool
-        """
-        if not old_userdb_format:
-            return self._data
-        old = copy.copy(self._data)
-        return old
 
 
 class NinList(PrimaryElementList):
@@ -143,14 +67,14 @@ class NinList(PrimaryElementList):
     :type nins: [dict | Nin]
     """
 
-    def __init__(self, nins, raise_on_unknown=True):
+    def __init__(self, nins):
         elements = []
 
         for this in nins:
             if isinstance(this, Nin):
                 nin = this
             else:
-                nin = nin_from_dict(this, raise_on_unknown)
+                nin = nin_from_dict(this)
             elements.append(nin)
 
         PrimaryElementList.__init__(self, elements)
@@ -182,15 +106,8 @@ class NinList(PrimaryElementList):
         PrimaryElementList.primary.fset(self, nin)
 
 
-def nin_from_dict(data, raise_on_unknown=True):
+def nin_from_dict(data: Dict[str, Any]) -> Nin:
     """
     Create a Nin instance from a dict.
-
-    :param data: Phone number parameters from database
-    :param raise_on_unknown: Raise exception on unknown values in `data' or not.
-
-    :type data: dict
-    :type raise_on_unknown: bool
-    :rtype: Nin
     """
-    return Nin.from_dict(data, raise_on_unknown=raise_on_unknown)
+    return Nin.from_dict(data)

--- a/src/eduid_userdb/nin.py
+++ b/src/eduid_userdb/nin.py
@@ -34,7 +34,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, ClassVar, Dict, Optional
+from typing import Any, Dict, Optional
 
 from eduid_userdb.element import PrimaryElement, PrimaryElementList
 
@@ -48,14 +48,23 @@ class Nin(PrimaryElement):
 
     number: Optional[str] = None
 
-    name_mapping: ClassVar[Dict[str, str]] = {'application': 'created_by'}
-
     @property
     def key(self) -> Optional[str]:
         """
         Return the element that is used as key for nin numberes in a PrimaryElementList.
         """
         return self.number
+
+    def _data_out_transforms(self, data: Dict[str, Any], old_userdb_format: bool = False) -> Dict[str, Any]:
+        """
+        Transform data kept in pythonic format into eduid format.
+        """
+        if 'created_by' in data:
+            data['application'] = data.pop('created_by')
+
+        data = super()._data_out_transforms(data, old_userdb_format)
+
+        return data
 
 
 class NinList(PrimaryElementList):

--- a/src/eduid_userdb/nin.py
+++ b/src/eduid_userdb/nin.py
@@ -55,17 +55,6 @@ class Nin(PrimaryElement):
         """
         return self.number
 
-    def _data_out_transforms(self, data: Dict[str, Any], old_userdb_format: bool = False) -> Dict[str, Any]:
-        """
-        Transform data kept in pythonic format into eduid format.
-        """
-        if 'created_by' in data:
-            data['application'] = data.pop('created_by')
-
-        data = super()._data_out_transforms(data, old_userdb_format)
-
-        return data
-
 
 class NinList(PrimaryElementList):
     """

--- a/src/eduid_userdb/orcid.py
+++ b/src/eduid_userdb/orcid.py
@@ -55,11 +55,11 @@ class OidcIdToken(Element, _OidcIdTokenRequired):
         return f'{self.iss}{self.sub}'
 
     @classmethod
-    def _data_in_transforms(cls: Type[OidcIdToken], data: Dict[str, Any]) -> Dict[str, Any]:
+    def _from_dict_transform(cls: Type[OidcIdToken], data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Transform data received in eduid format into pythonic format.
         """
-        data = super()._data_in_transforms(data)
+        data = super()._from_dict_transform(data)
 
         # these keys appear in the data sample in the eduid_userdb.tests.test_orcid module
         for key in ('at_hash', 'family_name', 'given_name', 'jti'):
@@ -98,10 +98,10 @@ class OidcAuthorization(Element, _OidcAuthorizationRequired):
         return self.id_token.key
 
     @classmethod
-    def _data_in_transforms(cls: Type[OidcAuthorization], data: Dict[str, Any]) -> Dict[str, Any]:
+    def _from_dict_transform(cls: Type[OidcAuthorization], data: Dict[str, Any]) -> Dict[str, Any]:
         """
         """
-        data = super()._data_in_transforms(data)
+        data = super()._from_dict_transform(data)
 
         # these keys appear in the data sample in the eduid_userdb.tests.test_orcid module
         for key in ('name', 'orcid', 'scope'):
@@ -117,10 +117,10 @@ class OidcAuthorization(Element, _OidcAuthorizationRequired):
 
         return data
 
-    def _data_out_transforms(self, data: Dict[str, Any]) -> Dict[str, Any]:
+    def _to_dict_transform(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """
         """
-        data = super()._data_out_transforms(data)
+        data = super()._to_dict_transform(data)
 
         data['id_token'] = self.id_token.to_dict()
         return data
@@ -154,10 +154,10 @@ class Orcid(VerifiedElement, _OrcidRequired):
         return self.id
 
     @classmethod
-    def _data_in_transforms(cls: Type[Orcid], data: Dict[str, Any]) -> Dict[str, Any]:
+    def _from_dict_transform(cls: Type[Orcid], data: Dict[str, Any]) -> Dict[str, Any]:
         """
         """
-        data = super()._data_in_transforms(data)
+        data = super()._from_dict_transform(data)
 
         # Parse ID token
         _oidc_authz = data.pop('oidc_authz')
@@ -168,14 +168,14 @@ class Orcid(VerifiedElement, _OrcidRequired):
 
         return data
 
-    def _data_out_transforms(self, data: Dict[str, Any]) -> Dict[str, Any]:
+    def _to_dict_transform(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """
         """
         data['oidc_authz'] = self.oidc_authz.to_dict()
 
         _has_empty_name = 'name' in data and data['name'] == None
 
-        data = super()._data_out_transforms(data)
+        data = super()._to_dict_transform(data)
 
         if _has_empty_name:
             # Be bug-compatible with earlier code, to be able to release dataclass based

--- a/src/eduid_userdb/orcid.py
+++ b/src/eduid_userdb/orcid.py
@@ -16,6 +16,7 @@ class _OidcIdTokenRequired:
     This is used to order the required args for OidcIdToken
     before the optional args for Element
     """
+
     # Issuer identifier
     iss: str
     # Subject identifier
@@ -33,6 +34,7 @@ class OidcIdToken(Element, _OidcIdTokenRequired):
     """
     OpenID Connect ID token data
     """
+
     # Nonce used to associate a Client session with an ID Token, and to mitigate replay attacks.
     nonce: Optional[str] = None
     # Time when the End-User authentication occurred.
@@ -44,7 +46,13 @@ class OidcIdToken(Element, _OidcIdTokenRequired):
     # Authorized party
     azp: Optional[str] = None
 
-    name_mapping: ClassVar[Dict[str, str]] = {'application': 'created_by', 'at_hash': '', 'family_name': '', 'given_name': '', 'jti': ''}
+    name_mapping: ClassVar[Dict[str, str]] = {
+        'application': 'created_by',
+        'at_hash': '',
+        'family_name': '',
+        'given_name': '',
+        'jti': '',
+    }
 
     @property
     def key(self) -> str:
@@ -60,6 +68,7 @@ class _OidcAuthorizationRequired:
     This is used to order the required args for OidcAuthorization
     before the optional args for Element
     """
+
     access_token: str
     token_type: str
     id_token: OidcIdToken
@@ -70,6 +79,7 @@ class OidcAuthorization(Element, _OidcAuthorizationRequired):
     """
     OpenID Connect Authorization data
     """
+
     expires_in: Optional[int] = None
     refresh_token: Optional[str] = None
 
@@ -85,9 +95,7 @@ class OidcAuthorization(Element, _OidcAuthorizationRequired):
         return self.id_token.key
 
     @classmethod
-    def data_in_transforms(
-        cls: Type[OidcAuthorization], data: Dict[str, Any]
-    ) -> Dict[str, Any]:
+    def data_in_transforms(cls: Type[OidcAuthorization], data: Dict[str, Any]) -> Dict[str, Any]:
         """
         """
         data = super().data_in_transforms(data)
@@ -115,6 +123,7 @@ class _OrcidRequired:
     """
     Required fields for Orcid
     """
+
     # User's ORCID
     id: str
     oidc_authz: OidcAuthorization
@@ -124,6 +133,7 @@ class _OrcidRequired:
 class Orcid(VerifiedElement, _OrcidRequired):
     """
     """
+
     name: Optional[str] = None
     given_name: Optional[str] = None
     family_name: Optional[str] = None

--- a/src/eduid_userdb/orcid.py
+++ b/src/eduid_userdb/orcid.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from typing import Any, ClassVar, Dict, List, Optional, Type
 
 from eduid_userdb.element import Element, VerifiedElement
@@ -73,8 +73,6 @@ class OidcAuthorization(Element, _OidcAuthorizationRequired):
     """
     expires_in: Optional[int] = None
     refresh_token: Optional[str] = None
-
-    name_mapping = {'application': 'created_by', 'name': '', 'orcid': '', 'scope': ''}
 
     @property
     def key(self) -> str:

--- a/src/eduid_userdb/orcid.py
+++ b/src/eduid_userdb/orcid.py
@@ -25,7 +25,8 @@ class _OidcIdTokenRequired:
     aud: List[str]
     # Expiration time
     exp: int
-    # What is this?
+    # Time at which the JWT was issued. Its value is a JSON number representing
+    # the number of seconds from 1970-01-01T0:0:0Z as measured in UTC until the date/time.
     iat: int
 
 

--- a/src/eduid_userdb/orcid.py
+++ b/src/eduid_userdb/orcid.py
@@ -74,6 +74,10 @@ class OidcAuthorization(Element, _OidcAuthorizationRequired):
     expires_in: Optional[int] = None
     refresh_token: Optional[str] = None
 
+    # XXX the data samples in the tests in test_orcid provide these keys,
+    # and here we remove them to avoid a TypeError.
+    name_mapping: ClassVar[Dict[str, str]] = {'name': '', 'orcid': '', 'scope': ''}
+
     @property
     def key(self) -> str:
         """

--- a/src/eduid_userdb/orcid.py
+++ b/src/eduid_userdb/orcid.py
@@ -24,7 +24,7 @@ class _OidcIdTokenRequired:
     aud: List[str]
     # Expiration time
     exp: int
-    # Expiration time
+    # What is this?
     iat: int
 
 
@@ -47,12 +47,11 @@ class OidcIdToken(Element, _OidcIdTokenRequired):
     name_mapping: ClassVar[Dict[str, str]] = {'application': 'created_by', 'at_hash': '', 'family_name': '', 'given_name': '', 'jti': ''}
 
     @property
-    def key(self):
+    def key(self) -> str:
         """
         :return: Unique identifier
-        :rtype: six.string_types
         """
-        return '{}{}'.format(self.iss, self.sub)
+        return f'{self.iss}{self.sub}'
 
 
 @dataclass
@@ -114,6 +113,7 @@ class OidcAuthorization(Element, _OidcAuthorizationRequired):
 @dataclass
 class _OrcidRequired:
     """
+    Required fields for Orcid
     """
     # User's ORCID
     id: str
@@ -131,7 +131,7 @@ class Orcid(VerifiedElement, _OrcidRequired):
     name_mapping: ClassVar[Dict[str, str]] = {'application': 'created_by'}
 
     @property
-    def key(self):
+    def key(self) -> str:
         """
         Unique id
         """

--- a/src/eduid_userdb/orcid.py
+++ b/src/eduid_userdb/orcid.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, asdict
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, ClassVar, Dict, List, Optional, Type
 
 from eduid_userdb.element import Element, VerifiedElement
 
@@ -44,7 +44,7 @@ class OidcIdToken(Element, _OidcIdTokenRequired):
     # Authorized party
     azp: Optional[str] = None
 
-    name_mapping = {'at_hash': '', 'family_name': '', 'given_name': '', 'jti': ''}
+    name_mapping: ClassVar[Dict[str, str]] = {'application': 'created_by', 'at_hash': '', 'family_name': '', 'given_name': '', 'jti': ''}
 
     @property
     def key(self):
@@ -74,7 +74,7 @@ class OidcAuthorization(Element, _OidcAuthorizationRequired):
     expires_in: Optional[int] = None
     refresh_token: Optional[str] = None
 
-    name_mapping = {'name': '', 'orcid': '', 'scope': ''}
+    name_mapping = {'application': 'created_by', 'name': '', 'orcid': '', 'scope': ''}
 
     @property
     def key(self) -> str:
@@ -125,6 +125,8 @@ class Orcid(VerifiedElement, _OrcidRequired):
     name: Optional[str] = None
     given_name: Optional[str] = None
     family_name: Optional[str] = None
+
+    name_mapping: ClassVar[Dict[str, str]] = {'application': 'created_by'}
 
     @property
     def key(self):

--- a/src/eduid_userdb/orcid.py
+++ b/src/eduid_userdb/orcid.py
@@ -2,73 +2,61 @@
 
 from __future__ import annotations
 
-import copy
-from typing import Any, Dict, Type
-
-from six import string_types
+from dataclasses import dataclass, asdict
+from typing import Any, Dict, List, Optional, Type
 
 from eduid_userdb.element import Element, VerifiedElement
-from eduid_userdb.exceptions import UserDBValueError, UserHasUnknownData
 
 __author__ = 'lundberg'
 
 
-class OidcIdToken(Element):
+@dataclass
+class _OidcIdTokenRequired:
+    """
+    This is used to order the required args for OidcIdToken
+    before the optional args for Element
+    """
+    # Issuer identifier
+    iss: str
+    # Subject identifier
+    sub: str
+    # Audience(s)
+    aud: List[str]
+    # Expiration time
+    exp: int
+    # Expiration time
+    iat: int
+
+
+@dataclass
+class OidcIdToken(Element, _OidcIdTokenRequired):
     """
     OpenID Connect ID token data
     """
-
-    def __init__(
-        self,
-        iss=None,
-        sub=None,
-        aud=None,
-        exp=None,
-        iat=None,
-        nonce=None,
-        auth_time=None,
-        acr=None,
-        amr=None,
-        azp=None,
-        application=None,
-        created_ts=None,
-        data=None,
-        raise_on_unknown=True,
-        called_directly=True,
-    ):
-        raise NotImplementedError()
+    # Nonce used to associate a Client session with an ID Token, and to mitigate replay attacks.
+    nonce: Optional[str] = None
+    # Time when the End-User authentication occurred.
+    auth_time: Optional[int] = None
+    # Authentication Context Class Reference
+    acr: Optional[str] = None
+    # Authentication Methods References
+    amr: Optional[List[str]] = None
+    # Authorized party
+    azp: Optional[str] = None
 
     @classmethod
-    def from_dict(cls: Type[OidcIdToken], data: Dict[str, Any], raise_on_unknown: bool = True) -> OidcIdToken:
+    def massage_data(
+        cls: Type[OidcIdToken], data: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """
-        Construct oidc id token from a data dict.
         """
-        data_in = data
-        data = copy.deepcopy(data_in)  # to not modify callers data
+        data = super().massage_data(data)
 
-        if not isinstance(data, dict):
-            raise UserDBValueError("Invalid 'data', not dict ({!r})".format(type(data)))
+        for key in ('at_hash', 'family_name', 'given_name', 'jti'):
+            if key in data:
+                del data[key]
 
-        if 'created_ts' not in data:
-            data['created_ts'] = True
-
-        self = super().from_dict(data)
-
-        self.iss = data.pop('iss')
-        self.sub = data.pop('sub')
-        self.aud = data.pop('aud')
-        self.exp = data.pop('exp')
-        self.iat = data.pop('iat')
-        self.nonce = data.pop('nonce', None)
-        self.auth_time = data.pop('auth_time', None)
-        self.acr = data.pop('acr', None)
-        self.amr = data.pop('amr', None)
-        self.azp = data.pop('azp', None)
-
-        if raise_on_unknown and data:
-            raise UserHasUnknownData('{!s} has unknown data: {!r}'.format(self.__class__.__name__, data.keys()))
-
-        return self
+        return data
 
     @property
     def key(self):
@@ -78,276 +66,46 @@ class OidcIdToken(Element):
         """
         return '{}{}'.format(self.iss, self.sub)
 
-    # -----------------------------------------------------------------
-    @property
-    def iss(self):
-        """
-        Issuer identifier
 
-        :return: Issuer url
-        :rtype: six.string_types
-        """
-        return self._data['iss']
-
-    @iss.setter
-    def iss(self, value):
-        """
-        :param value: Issuer
-        :type value: six.string_types
-        """
-        if not value or not isinstance(value, string_types):
-            raise UserDBValueError("Invalid 'iss': {!r}".format(value))
-        self._data['iss'] = value
-
-    # -----------------------------------------------------------------
-    @property
-    def sub(self):
-        """
-        Subject identifier
-
-        :return: subject id
-        :rtype: six.string_types
-        """
-        return self._data['sub']
-
-    @sub.setter
-    def sub(self, value):
-        """
-        :param value: Subject id
-        :type value: six.string_types
-        """
-        if not value or not isinstance(value, string_types):
-            raise UserDBValueError("Invalid 'sub': {!r}".format(value))
-        self._data['sub'] = value
-
-    # -----------------------------------------------------------------
-    @property
-    def aud(self):
-        """
-        Audience(s)
-
-        :return: audience list
-        :rtype: list
-        """
-        return self._data['aud']
-
-    @aud.setter
-    def aud(self, value):
-        """
-        :param value: audience list
-        :type value: list
-        """
-        if not isinstance(value, list):
-            raise UserDBValueError("Invalid 'aud': {!r}".format(value))
-        self._data['aud'] = value
-
-    # -----------------------------------------------------------------
-    @property
-    def exp(self):
-        """
-        Expiration time
-
-        :return: expiration time
-        :rtype: int
-        """
-        return self._data['exp']
-
-    @exp.setter
-    def exp(self, value):
-        """
-        :param value: expiration time
-        :type value: int
-        """
-        if not isinstance(value, int):
-            raise UserDBValueError("Invalid 'exp': {!r}".format(value))
-        self._data['exp'] = value
-
-    # -----------------------------------------------------------------
-    @property
-    def iat(self):
-        """
-        Expiration time
-
-        :return: expiration time
-        :rtype: int
-        """
-        return self._data['iat']
-
-    @iat.setter
-    def iat(self, value):
-        """
-        :param value: expiration time
-        :type value: int
-        """
-        if not isinstance(value, int):
-            raise UserDBValueError("Invalid 'iat': {!r}".format(value))
-        self._data['iat'] = value
-
-    # -----------------------------------------------------------------
-    @property
-    def nonce(self):
-        """
-        Nonce used to associate a Client session with an ID Token, and to mitigate replay attacks.
-
-        :return: nonce
-        :rtype: six.string_types
-        """
-        return self._data.get('nonce')
-
-    @nonce.setter
-    def nonce(self, value):
-        """
-        :param value: nonce
-        :type value: six.string_types | None
-        """
-        if value is not None:  # No op for value None
-            if not isinstance(value, string_types):
-                raise UserDBValueError("Invalid 'nonce': {!r}".format(value))
-            self._data['nonce'] = value
-
-    # -----------------------------------------------------------------
-    @property
-    def auth_time(self):
-        """
-        Time when the End-User authentication occurred.
-
-        :return: auth time
-        :rtype: int
-        """
-        return self._data.get('auth_time')
-
-    @auth_time.setter
-    def auth_time(self, value):
-        """
-        :param value: auth time
-        :type value: int
-        """
-        if value is not None:  # No op for value None
-            if not isinstance(value, int):
-                raise UserDBValueError("Invalid 'auth_time': {!r}".format(value))
-            self._data['auth_time'] = value
-
-    # -----------------------------------------------------------------
-    @property
-    def acr(self):
-        """
-        Authentication Context Class Reference
-
-        :return: acr
-        :rtype: six.string_types
-        """
-        return self._data.get('acr')
-
-    @acr.setter
-    def acr(self, value):
-        """
-        :param value: acr
-        :type value: six.string_types
-        """
-        if value is not None:  # No op for value None
-            if not isinstance(value, string_types):
-                raise UserDBValueError("Invalid 'acr': {!r}".format(value))
-            self._data['acr'] = value
-
-    # -----------------------------------------------------------------
-    @property
-    def amr(self):
-        """
-        Authentication Methods References
-
-        :return: nin number.
-        :rtype: list
-        """
-        return self._data.get('amr')
-
-    @amr.setter
-    def amr(self, value):
-        """
-        :param value: nin number.
-        :type value: list
-        """
-        if value is not None:  # No op for value None
-            if not isinstance(value, list):
-                raise UserDBValueError("Invalid 'amr': {!r}".format(value))
-            self._data['amr'] = value
-
-    # -----------------------------------------------------------------
-    @property
-    def azp(self):
-        """
-        Authorized party
-
-        :return: acr
-        :rtype: six.string_types
-        """
-        return self._data.get('azp')
-
-    @azp.setter
-    def azp(self, value):
-        """
-        :param value: acr
-        :type value: six.string_types
-        """
-        if value is not None:  # No op for value None
-            if not isinstance(value, string_types):
-                raise UserDBValueError("Invalid 'azp': {!r}".format(value))
-            self._data['azp'] = value
+@dataclass
+class _OidcAuthorizationRequired:
+    """
+    This is used to order the required args for OidcAuthorization
+    before the optional args for Element
+    """
+    access_token: str
+    token_type: str
+    id_token: OidcIdToken
 
 
-class OidcAuthorization(Element):
+@dataclass
+class OidcAuthorization(Element, _OidcAuthorizationRequired):
     """
     OpenID Connect Authorization data
     """
-
-    def __init__(
-        self,
-        access_token=None,
-        token_type=None,
-        id_token=None,
-        expires_in=None,
-        refresh_token=None,
-        application=None,
-        created_ts=None,
-        data=None,
-        raise_on_unknown=True,
-        called_directly=True,
-    ):
-        raise NotImplementedError()
+    expires_in: Optional[int] = None
+    refresh_token: Optional[str] = None
 
     @classmethod
-    def from_dict(
-        cls: Type[OidcAuthorization], data: Dict[str, Any], raise_on_unknown: bool = True
-    ) -> OidcAuthorization:
+    def massage_data(
+        cls: Type[OidcAuthorization], data: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """
-        Construct user from a data dict.
         """
-        data_in = data
-        data = copy.deepcopy(data_in)  # to not modify callers data
-
-        if not isinstance(data, dict):
-            raise UserDBValueError("Invalid 'data', not dict ({!r})".format(type(data)))
-
-        if 'created_ts' not in data:
-            data['created_ts'] = True
-
-        self = super().from_dict(data)
-
-        self.access_token = data.pop('access_token')
-        self.token_type = data.pop('token_type')
-        self.expires_in = data.pop('expires_in')
-        self.refresh_token = data.pop('refresh_token')
+        data = super().massage_data(data)
 
         # Parse ID token
         _id_token = data.pop('id_token')
         if isinstance(_id_token, dict):
-            self.id_token = OidcIdToken.from_dict(_id_token, raise_on_unknown=raise_on_unknown)
-        if isinstance(_id_token, OidcIdToken):
-            self.id_token = _id_token
+            data['id_token'] = OidcIdToken.from_dict(_id_token)
+        elif isinstance(_id_token, OidcIdToken):
+            data['id_token'] = _id_token
 
-        if raise_on_unknown and data:
-            raise UserHasUnknownData('{!s} has unknown data: {!r}'.format(self.__class__.__name__, data.keys()))
+        for key in ('name', 'orcid', 'scope'):
+            if key in data:
+                del data[key]
 
-        return self
+        return data
 
     @property
     def key(self):
@@ -357,187 +115,48 @@ class OidcAuthorization(Element):
         """
         return self.id_token.key
 
-    # -----------------------------------------------------------------
-    @property
-    def access_token(self):
-        """
-        Access token
-
-        :return: access token
-        :rtype: six.string_types
-        """
-        return self._data['access_token']
-
-    @access_token.setter
-    def access_token(self, value):
-        """
-        :param value: Access token
-        :type value: six.string_types
-        """
-        if not value or not isinstance(value, string_types):
-            raise UserDBValueError("Invalid 'access_token': {!r}".format(value))
-        self._data['access_token'] = value
-
-    # -----------------------------------------------------------------
-    @property
-    def token_type(self):
-        """
-        Token type
-
-        :return: token type
-        :rtype: six.string_types
-        """
-        return self._data['sub']
-
-    @token_type.setter
-    def token_type(self, value):
-        """
-        :param value: token type
-        :type value: six.string_types
-        """
-        if not value or not isinstance(value, string_types):
-            raise UserDBValueError("Invalid 'token_type': {!r}".format(value))
-        self._data['token_type'] = value.lower()  # Case insensitive
-
-    # -----------------------------------------------------------------
-    @property
-    def id_token(self):
-        """
-        ID Token
-
-        :return: id token
-        :rtype: six.string_types
-        """
-        return self._data['id_token']
-
-    @id_token.setter
-    def id_token(self, value):
-        """
-        :param value: id token
-        :type value: six.string_types
-        """
-        if not isinstance(value, OidcIdToken):
-            raise UserDBValueError("Invalid 'id_token': {!r}".format(value))
-        self._data['id_token'] = value
-
-    # -----------------------------------------------------------------
-    @property
-    def expires_in(self):
-        """
-        The lifetime in seconds of the access token.
-
-        :return: expires in
-        :rtype: int
-        """
-        return self._data.get('expires_in')
-
-    @expires_in.setter
-    def expires_in(self, value):
-        """
-        :param value: expires in
-        :type value: int
-        """
-        if value is not None:  # No op for value None
-            if not isinstance(value, int):
-                raise UserDBValueError("Invalid 'expires_in': {!r}".format(value))
-            self._data['expires_in'] = value
-
-    # -----------------------------------------------------------------
-    @property
-    def refresh_token(self):
-        """
-        Refresh token
-
-        :return: refresh token
-        :rtype: six.string_types
-        """
-        return self._data.get('refresh_token')
-
-    @refresh_token.setter
-    def refresh_token(self, value):
-        """
-        :param value: refresh token
-        :type value: six.string_types
-        """
-        if value is not None:  # No op for value None
-            if not isinstance(value, string_types):
-                raise UserDBValueError("Invalid 'refresh_token': {!r}".format(value))
-            self._data['refresh_token'] = value
-
-    def to_dict(self, old_userdb_format=False):
+    def to_dict(self) -> Dict[str, Any]:
         """
         Convert OidcAuthorization to a dict
-
-        :param old_userdb_format: Set to True to get data back in legacy format.
-        :type old_userdb_format: bool
-
-        :return data dict
-        :rtype dict
         """
-        data = copy.deepcopy(self._data)
+        data = asdict(self)
         data['id_token'] = self.id_token.to_dict()
         return data
 
 
-class Orcid(VerifiedElement):
+@dataclass
+class _OrcidRequired:
     """
-    :param data: Orcid parameters from database
-    :param raise_on_unknown: Raise exception on unknown values in `data' or not.
-
-    :type data: dict
-    :type raise_on_unknown: bool
     """
+    # User's ORCID
+    id: str
+    oidc_authz: OidcAuthorization
 
-    def __init__(
-        self,
-        id=None,
-        name=None,
-        given_name=None,
-        family_name=None,
-        oidc_authz=None,
-        application=None,
-        verified=False,
-        created_ts=None,
-        data=None,
-        raise_on_unknown=True,
-        called_directly=True,
-    ):
-        raise NotImplementedError()
+
+@dataclass
+class Orcid(VerifiedElement, _OrcidRequired):
+    """
+    """
+    name: Optional[str] = None
+    given_name: Optional[str] = None
+    family_name: Optional[str] = None
 
     @classmethod
-    def from_dict(cls: Type[Orcid], data: Dict[str, Any], raise_on_unknown: bool = True) -> Orcid:
+    def massage_data(cls: Type[Orcid], data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Construct user from a data dict.
         """
-        data_in = data
-        data = copy.deepcopy(data_in)  # to not modify callers data
-
-        if not isinstance(data, dict):
-            raise UserDBValueError("Invalid 'data', not dict ({!r})".format(type(data)))
-
-        if 'created_ts' not in data:
-            data['created_ts'] = True
-
-        self = super().from_dict(data)
-
-        self.id = data.pop('id')
-        self.name = data.pop('name', None)
-        self.given_name = data.pop('given_name', None)
-        self.family_name = data.pop('family_name', None)
+        data = super().massage_data(data)
 
         # Parse ID token
         _oidc_authz = data.pop('oidc_authz')
         if isinstance(_oidc_authz, dict):
-            self.oidc_authz = OidcAuthorization.from_dict(_oidc_authz)
+            data['oidc_authz'] = OidcAuthorization.from_dict(_oidc_authz)
         if isinstance(_oidc_authz, OidcAuthorization):
-            self.oidc_authz = _oidc_authz
+            data['oidc_authz'] = _oidc_authz
 
-        if raise_on_unknown and data:
-            raise UserHasUnknownData('{!s} has unknown data: {!r}'.format(self.__class__.__name__, data.keys()))
+        return data
 
-        return self
-
-    # -----------------------------------------------------------------
     @property
     def key(self):
         """
@@ -545,120 +164,11 @@ class Orcid(VerifiedElement):
         """
         return self.id
 
-    # -----------------------------------------------------------------
-    @property
-    def id(self):
-        """
-        Users ORCID
-
-        :return: orcid
-        :rtype: six.string_types
-        """
-        return self._data['id']
-
-    @id.setter
-    def id(self, value):
-        """
-        :param value: ORCID
-        :type value: str | unicode
-        """
-        if not value or not isinstance(value, string_types):
-            raise UserDBValueError("Invalid 'id': {!r}".format(value))
-        self._data['id'] = str(value.lower())  # Case insensitive
-
-    # -----------------------------------------------------------------
-    @property
-    def name(self):
-        """
-        Users name
-
-        :return: name
-        :rtype: six.string_types
-        """
-        return self._data['name']
-
-    @name.setter
-    def name(self, value):
-        """
-        :param value: name
-        :type value: str | unicode | None
-        """
-        if value is not None and not isinstance(value, string_types):
-            raise UserDBValueError("Invalid 'name': {!r}".format(value))
-        self._data['name'] = value
-
-    # -----------------------------------------------------------------
-    @property
-    def given_name(self):
-        """
-        Users given_name
-
-        :return: given name
-        :rtype: six.string_types
-        """
-        return self._data['given_name']
-
-    @given_name.setter
-    def given_name(self, value):
-        """
-        :param value: given name
-        :type value: str | unicode | None
-        """
-        if value is not None and not isinstance(value, string_types):
-            raise UserDBValueError("Invalid 'given_name': {!r}".format(value))
-        self._data['given_name'] = value
-
-    # -----------------------------------------------------------------
-    @property
-    def family_name(self):
-        """
-        Users family name
-
-        :return: family name
-        :rtype: six.string_types
-        """
-        return self._data['family_name']
-
-    @family_name.setter
-    def family_name(self, value):
-        """
-        :param value: family name
-        :type value: str | unicode | None
-        """
-        if value is not None and not isinstance(value, string_types):
-            raise UserDBValueError("Invalid 'family_name': {!r}".format(value))
-        self._data['family_name'] = value
-
-    # -----------------------------------------------------------------
-    @property
-    def oidc_authz(self):
-        """
-        Users ORCID OIDC authorization data
-
-        :return: oidc authorization data
-        :rtype: OidcAuthorization
-        """
-        return self._data['oidc_authz']
-
-    @oidc_authz.setter
-    def oidc_authz(self, value):
-        """
-        :param value: oidc authorization data
-        :type value: OidcAuthorization
-        """
-        if not isinstance(value, OidcAuthorization):
-            raise UserDBValueError("Invalid 'oidc_authz': {!r}".format(value))
-        self._data['oidc_authz'] = value
-
-    # -----------------------------------------------------------------
-    def to_dict(self, old_userdb_format=False):
+    def to_dict(self):
         """
         Convert Element to a dict, that can be used to reconstruct the
         Element later.
-
-        :param old_userdb_format: Set to True to get data back in legacy format.
-        :type old_userdb_format: bool
         """
-        data = copy.deepcopy(self._data)
+        data = asdict(self)
         data['oidc_authz'] = self.oidc_authz.to_dict()
         return data

--- a/src/eduid_userdb/phone.py
+++ b/src/eduid_userdb/phone.py
@@ -56,11 +56,11 @@ class PhoneNumber(PrimaryElement):
         return self.number
 
     @classmethod
-    def _data_in_transforms(cls: Type[PhoneNumber], data: Dict[str, Any]) -> Dict[str, Any]:
+    def _from_dict_transform(cls: Type[PhoneNumber], data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Transform data received in eduid format into pythonic format.
         """
-        data = super()._data_in_transforms(data)
+        data = super()._from_dict_transform(data)
 
         if 'added_timestamp' in data:
             data['created_ts'] = data.pop('added_timestamp')

--- a/src/eduid_userdb/phone.py
+++ b/src/eduid_userdb/phone.py
@@ -45,9 +45,15 @@ __author__ = 'ft'
 class PhoneNumber(PrimaryElement):
     """
     """
+
     number: Optional[str] = None
 
-    name_mapping: ClassVar[Dict[str, str]] = {'application': 'created_by', 'added_timestamp': 'created_ts', 'mobile': 'number', 'csrf': ''}
+    name_mapping: ClassVar[Dict[str, str]] = {
+        'application': 'created_by',
+        'added_timestamp': 'created_ts',
+        'mobile': 'number',
+        'csrf': '',
+    }
     old_names: ClassVar[tuple] = ('added_timestamp', 'mobile')
 
     @property

--- a/src/eduid_userdb/phone.py
+++ b/src/eduid_userdb/phone.py
@@ -51,7 +51,7 @@ class PhoneNumber(PrimaryElement):
     old_names: ClassVar[tuple] = ('added_timestamp', 'mobile')
 
     @property
-    def key(self) -> str:
+    def key(self) -> Optional[str]:
         """
         Return the element that is used as key for phone numbers in a PrimaryElementList.
         """

--- a/src/eduid_userdb/phone.py
+++ b/src/eduid_userdb/phone.py
@@ -47,54 +47,16 @@ class PhoneNumber(PrimaryElement):
     """
     number: Optional[str] = None
 
-    @classmethod
-    def massage_data(
-        cls: Type[PhoneNumber], data: Dict[str, Any]
-    ) -> Dict[str, Any]:
-        """
-        """
-        data = super().massage_data(data)
+    name_mapping = {'added_timestamp': 'created_ts', 'mobile': 'number', 'csrf': ''}
+    old_names = ('added_timestamp', 'mobile')
 
-        if 'added_timestamp' in data:
-            # old userdb-style creation timestamp
-            data['created_ts'] = data.pop('added_timestamp')
 
-        if 'mobile' in data:
-            # old userdb-style entry
-            data['number'] = data.pop('mobile')
-
-        # CSRF tokens were accidentally put in the database some time ago
-        if 'csrf' in data:
-            del data['csrf']
-
-        return data
-
-    # -----------------------------------------------------------------
     @property
     def key(self):
         """
         Return the element that is used as key for phone numbers in a PrimaryElementList.
         """
         return self.number
-
-    def to_dict(self, old_userdb_format: bool = False) -> Dict[str, Any]:
-        """
-        Convert Element to a dict, that can be used to reconstruct the
-        Element later.
-
-        :param old_userdb_format: Set to True to get data back in legacy format.
-        """
-        data = asdict(self)
-        if not old_userdb_format:
-            return data
-
-        # XXX created_ts -> added_timestamp
-        if 'created_ts' in data:
-            data['added_timestamp'] = data.pop('created_ts')
-        if 'number' in data:
-            data['mobile'] = data.pop('number')
-
-        return data
 
 
 class PhoneNumberList(PrimaryElementList):

--- a/src/eduid_userdb/phone.py
+++ b/src/eduid_userdb/phone.py
@@ -34,7 +34,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, asdict
-from typing import Any, Dict, Optional, Type
+from typing import Any, ClassVar, Dict, Optional, Type
 
 from eduid_userdb.element import PrimaryElement, PrimaryElementList
 
@@ -47,9 +47,8 @@ class PhoneNumber(PrimaryElement):
     """
     number: Optional[str] = None
 
-    name_mapping = {'added_timestamp': 'created_ts', 'mobile': 'number', 'csrf': ''}
-    old_names = ('added_timestamp', 'mobile')
-
+    name_mapping: ClassVar[Dict[str, str]] = {'application': 'created_by', 'added_timestamp': 'created_ts', 'mobile': 'number', 'csrf': ''}
+    old_names: ClassVar[tuple] = ('added_timestamp', 'mobile')
 
     @property
     def key(self):

--- a/src/eduid_userdb/phone.py
+++ b/src/eduid_userdb/phone.py
@@ -73,24 +73,6 @@ class PhoneNumber(PrimaryElement):
 
         return data
 
-    def _data_out_transforms(self, data: Dict[str, Any], old_userdb_format: bool = False) -> Dict[str, Any]:
-        """
-        Transform data kept in pythonic format into eduid format.
-        """
-        if 'created_by' in data:
-            data['application'] = data.pop('created_by')
-
-        if old_userdb_format:
-            if 'created_ts' in data:
-                data['added_timestamp'] = data.pop('created_ts')
-
-            if 'number' in data:
-                data['mobile'] = data.pop('number')
-
-        data = super()._data_out_transforms(data, old_userdb_format)
-
-        return data
-
 
 class PhoneNumberList(PrimaryElementList):
     """

--- a/src/eduid_userdb/phone.py
+++ b/src/eduid_userdb/phone.py
@@ -33,8 +33,8 @@
 #
 from __future__ import annotations
 
-from dataclasses import dataclass, asdict
-from typing import Any, ClassVar, Dict, Optional, Type
+from dataclasses import dataclass
+from typing import Any, ClassVar, Dict, Optional
 
 from eduid_userdb.element import PrimaryElement, PrimaryElementList
 
@@ -51,7 +51,7 @@ class PhoneNumber(PrimaryElement):
     old_names: ClassVar[tuple] = ('added_timestamp', 'mobile')
 
     @property
-    def key(self):
+    def key(self) -> str:
         """
         Return the element that is used as key for phone numbers in a PrimaryElementList.
         """

--- a/src/eduid_userdb/profile.py
+++ b/src/eduid_userdb/profile.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
-from typing import Any, Dict, List, Mapping, Optional, Union
+from typing import Any, Dict, List, Mapping, Optional
 
 from eduid_userdb.element import DuplicateElementViolation, Element, ElementList
 from eduid_userdb.exceptions import UserDBValueError

--- a/src/eduid_userdb/profile.py
+++ b/src/eduid_userdb/profile.py
@@ -15,6 +15,7 @@ __author__ = 'lundberg'
 class Profile(Element):
     """
     """
+
     owner: Optional[str] = None
     schema: Optional[str] = None
     profile_data: Optional[Mapping[str, Any]] = None

--- a/src/eduid_userdb/profile.py
+++ b/src/eduid_userdb/profile.py
@@ -12,13 +12,19 @@ __author__ = 'lundberg'
 
 
 @dataclass
-class Profile(Element):
+class _ProfileRequired:
     """
     """
 
-    owner: Optional[str] = None
-    schema: Optional[str] = None
-    profile_data: Optional[Mapping[str, Any]] = None
+    owner: str
+    schema: str
+    profile_data: Mapping[str, Any]
+
+
+@dataclass
+class Profile(Element, _ProfileRequired):
+    """
+    """
 
     @property
     def key(self) -> Optional[str]:

--- a/src/eduid_userdb/profile.py
+++ b/src/eduid_userdb/profile.py
@@ -20,7 +20,7 @@ class Profile(Element):
     profile_data: Optional[Mapping[str, Any]] = None
 
     @property
-    def key(self) -> str:
+    def key(self) -> Optional[str]:
         """ Return the element that is used as key in a ElementList """
         return self.owner
 

--- a/src/eduid_userdb/profile.py
+++ b/src/eduid_userdb/profile.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Dict, List, Mapping, Optional, Union
 
@@ -11,78 +12,18 @@ from eduid_userdb.exceptions import UserDBValueError
 __author__ = 'lundberg'
 
 
+@dataclass
 class Profile(Element):
-    def __init__(
-        self,
-        owner: str,
-        schema: str,
-        profile_data: Mapping[str, Any],
-        created_by: Optional[str] = None,
-        created_ts: Optional[Union[datetime, bool]] = None,
-        modified_ts: Optional[Union[datetime, bool]] = None,
-    ):
+    """
+    """
+    owner: Optional[str] = None
+    schema: Optional[str] = None
+    profile_data: Optional[Mapping[str, Any]] = None
 
-        if created_ts is None:
-            created_ts = True
-        # do not deprecate direct calls to the __init__ of Profile,
-        # since it does not accept a data dict, and is already very near a dataclass
-        # Once Element is a dataclass, we can remove the lines below up till EOR
-        # and rely on super
-        self._data: Dict[str, Any] = {}
-
-        self.created_by = created_by
-        self.created_ts = created_ts
-        self.modified_ts = modified_ts
-        # EOR
-
-        self.owner = owner
-        self.schema = schema
-        self.profile_data = profile_data
-
-    # -----------------------------------------------------------------
     @property
     def key(self) -> str:
         """ Return the element that is used as key in a ElementList """
         return self.owner
-
-    # -----------------------------------------------------------------
-    @property
-    def owner(self) -> str:
-        """ Name of the profile owner """
-        return self._data['owner']
-
-    @owner.setter
-    def owner(self, value: str) -> None:
-        """ Name of profile owner """
-        if not isinstance(value, str):
-            raise UserDBValueError(f"Invalid 'owner': {repr(value)}")
-        self._data['owner'] = value.lower()
-
-    # -----------------------------------------------------------------
-    @property
-    def schema(self) -> str:
-        """ This is the schema identifier for schema used for the external data """
-        return self._data['schema']
-
-    @schema.setter
-    def schema(self, value: str) -> None:
-        """ Schema identifier for schema used for the external data"""
-        if not isinstance(value, str):
-            raise UserDBValueError(f"Invalid 'schema': {repr(value)}")
-        self._data['schema'] = value.lower()
-
-    # -----------------------------------------------------------------
-    @property
-    def profile_data(self) -> Mapping[str, Any]:
-        """ This is the schema identifier used for the external data """
-        return self._data['profile_data']
-
-    @profile_data.setter
-    def profile_data(self, value: Mapping[str, Any]) -> None:
-        """ Opaque profile data """
-        if not isinstance(value, Mapping):
-            raise UserDBValueError(f"Invalid 'profile_data': {repr(value)}")
-        self._data['profile_data'] = value
 
 
 class ProfileList(ElementList):
@@ -110,5 +51,5 @@ class ProfileList(ElementList):
     def from_list_of_dicts(cls, items: List[Dict[str, Any]]) -> ProfileList:
         profiles = list()
         for item in items:
-            profiles.append(Profile(**item))
+            profiles.append(Profile.from_dict(item))
         return cls(profiles=profiles)

--- a/src/eduid_userdb/proofing/db.py
+++ b/src/eduid_userdb/proofing/db.py
@@ -266,7 +266,7 @@ class ProofingUserDB(UserDB):
     def __init__(self, db_uri, db_name, collection='profiles'):
         super(ProofingUserDB, self).__init__(db_uri, db_name, collection=collection)
 
-    def save(self, user, check_sync=True, old_format=False):
+    def save(self, user, check_sync=True, old_format: Optional[bool] = None):
         super(ProofingUserDB, self).save(user, check_sync=check_sync, old_format=old_format)
 
 

--- a/src/eduid_userdb/proofing/element.py
+++ b/src/eduid_userdb/proofing/element.py
@@ -34,11 +34,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import ClassVar, Dict, Optional
+from typing import Any, Dict, Optional, Type, TypeVar
 
 from eduid_userdb.element import Element, VerifiedElement
 
 __author__ = 'lundberg'
+
+
+TProofingElementSubclass = TypeVar('TProofingElementSubclass', bound='ProofingElement')
 
 
 @dataclass
@@ -59,9 +62,20 @@ class ProofingElement(VerifiedElement):
 
     verification_code: Optional[str] = None
 
-    # this seems redundant but it is not: VerifiedElement's name_mapping eliminates the
-    # verification_code key, and here we replace it.
-    name_mapping: ClassVar[Dict[str, str]] = {'verification_code': 'verification_code'}
+    @classmethod
+    def _data_in_transforms(cls: Type[TProofingElementSubclass], data: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Transform data received in eduid format into pythonic format.
+        """
+        # VerifiedElement._data_in_transforms eliminates the verification_code key, and here we keep it.
+        code = data.pop('verification_code', None)
+
+        data = super()._data_in_transforms(data)
+
+        if code is not None:
+            data['verification_code'] = code
+
+        return data
 
 
 @dataclass

--- a/src/eduid_userdb/proofing/element.py
+++ b/src/eduid_userdb/proofing/element.py
@@ -64,7 +64,7 @@ class ProofingElement(VerifiedElement):
 
 
 @dataclass
-class _NumberProofingElementRequired(ProofingElement):
+class _NumberProofingElementRequired:
     """
     """
     number: str
@@ -92,7 +92,7 @@ class NinProofingElement(ProofingElement, _NumberProofingElementRequired):
 
 
 @dataclass
-class _EmailProofingElementRequired(ProofingElement):
+class _EmailProofingElementRequired:
     """
     """
     email: str

--- a/src/eduid_userdb/proofing/element.py
+++ b/src/eduid_userdb/proofing/element.py
@@ -63,14 +63,14 @@ class ProofingElement(VerifiedElement):
     verification_code: Optional[str] = None
 
     @classmethod
-    def _data_in_transforms(cls: Type[TProofingElementSubclass], data: Dict[str, Any]) -> Dict[str, Any]:
+    def _from_dict_transform(cls: Type[TProofingElementSubclass], data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Transform data received in eduid format into pythonic format.
         """
-        # VerifiedElement._data_in_transforms eliminates the verification_code key, and here we keep it.
+        # VerifiedElement._from_dict_transform eliminates the verification_code key, and here we keep it.
         code = data.pop('verification_code', None)
 
-        data = super()._data_in_transforms(data)
+        data = super()._from_dict_transform(data)
 
         if code is not None:
             data['verification_code'] = code

--- a/src/eduid_userdb/proofing/element.py
+++ b/src/eduid_userdb/proofing/element.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional
+from typing import ClassVar, Dict, Optional
 
 from eduid_userdb.element import Element, VerifiedElement
 
@@ -61,6 +61,8 @@ class ProofingElement(VerifiedElement):
     :type data: dict
     """
     verification_code: Optional[str] = None
+
+    name_mapping: ClassVar[Dict[str, str]] = {'verification_code': 'verification_code'}
 
 
 @dataclass

--- a/src/eduid_userdb/proofing/element.py
+++ b/src/eduid_userdb/proofing/element.py
@@ -55,19 +55,18 @@ class ProofingElement(VerifiedElement):
         verified_by
         verified_ts
         verification_code
-
-    :param data: element parameters from database
-
-    :type data: dict
     """
     verification_code: Optional[str] = None
 
+    # this seems redundant but it is not: VerifiedElement's name_mapping eliminates the
+    # verification_code key, and here we replace it.
     name_mapping: ClassVar[Dict[str, str]] = {'verification_code': 'verification_code'}
 
 
 @dataclass
 class _NumberProofingElementRequired:
     """
+    Required fields for NinProofingElement and PhoneProofingElement
     """
     number: str
 
@@ -86,16 +85,13 @@ class NinProofingElement(ProofingElement, _NumberProofingElementRequired):
         verified_by
         verified_ts
         verification_code
-
-    :param data: element parameters from database
-
-    :type data: dict
     """
 
 
 @dataclass
 class _EmailProofingElementRequired:
     """
+    Required fields for EmailProofingElement
     """
     email: str
 
@@ -114,10 +110,6 @@ class EmailProofingElement(ProofingElement, _EmailProofingElementRequired):
         verified_by
         verified_ts
         verification_code
-
-    :param data: element parameters from database
-
-    :type data: dict
     """
 
 
@@ -135,10 +127,6 @@ class PhoneProofingElement(ProofingElement, _NumberProofingElementRequired):
         verified_by
         verified_ts
         verification_code
-
-    :param data: element parameters from database
-
-    :type data: dict
     """
 
 

--- a/src/eduid_userdb/proofing/element.py
+++ b/src/eduid_userdb/proofing/element.py
@@ -56,6 +56,7 @@ class ProofingElement(VerifiedElement):
         verified_ts
         verification_code
     """
+
     verification_code: Optional[str] = None
 
     # this seems redundant but it is not: VerifiedElement's name_mapping eliminates the
@@ -68,6 +69,7 @@ class _NumberProofingElementRequired:
     """
     Required fields for NinProofingElement and PhoneProofingElement
     """
+
     number: str
 
 
@@ -93,6 +95,7 @@ class _EmailProofingElementRequired:
     """
     Required fields for EmailProofingElement
     """
+
     email: str
 
 
@@ -142,6 +145,7 @@ class SentLetterElement(Element):
     created_by
     created_ts
     """
+
     is_sent: bool = False
     sent_ts: Optional[datetime] = None
     transaction_id: Optional[str] = None

--- a/src/eduid_userdb/proofing/element.py
+++ b/src/eduid_userdb/proofing/element.py
@@ -32,17 +32,16 @@
 #
 from __future__ import annotations
 
-from typing import Any, Dict, Type
-import copy
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
 
-from six import string_types
-
-from eduid_userdb.element import Element, VerifiedElement, _set_something_by, _set_something_ts
-from eduid_userdb.exceptions import UserDBValueError
+from eduid_userdb.element import Element, VerifiedElement
 
 __author__ = 'lundberg'
 
 
+@dataclass
 class ProofingElement(VerifiedElement):
     """
     Element for holding the state of a proofing flow. It should contain meta data needed for logging
@@ -61,58 +60,18 @@ class ProofingElement(VerifiedElement):
 
     :type data: dict
     """
-
-    def __init__(
-        self,
-        application=None,
-        created_ts=None,
-        verified=False,
-        verified_by=None,
-        verified_ts=None,
-        verification_code=None,
-        data=None,
-        called_directly=True,
-    ):
-        raise NotImplementedError()
-
-    @classmethod
-    def from_dict(cls: Type[ProofingElement], data: Dict[str, Any], raise_on_unknown: bool = True) -> ProofingElement:
-        """
-        Construct proofing element from a data dict.
-        """
-        data_in = copy.copy(data)  # to not modify callers data
-
-        if 'created_ts' not in data:
-            data['created_ts'] = True
-
-        verification_code = data_in.pop('verification_code', None)
-        self = super().from_dict(data_in)
-        self.verification_code = verification_code
-
-        return self
-
-    @property
-    def verification_code(self):
-        """
-        :return: Confirmation code used to verify this element.
-        :rtype: str | unicode
-        """
-        return self._data['verification_code']
-
-    @verification_code.setter
-    def verification_code(self, value):
-        """
-        :param value: New verification_code
-        :type value: str | unicode | None
-        """
-        if value is None:
-            return
-        if not isinstance(value, string_types):
-            raise UserDBValueError("Invalid 'verification_code': {!r}".format(value))
-        self._data['verification_code'] = value
+    verification_code: Optional[str] = None
 
 
-class NinProofingElement(ProofingElement):
+@dataclass
+class _NumberProofingElementRequired(ProofingElement):
+    """
+    """
+    number: str
+
+
+@dataclass
+class NinProofingElement(ProofingElement, _NumberProofingElementRequired):
     """
     Element for holding the state of a nin proofing flow.
 
@@ -131,57 +90,16 @@ class NinProofingElement(ProofingElement):
     :type data: dict
     """
 
-    def __init__(
-        self,
-        number=None,
-        application=None,
-        created_ts=None,
-        verified=False,
-        verification_code=None,
-        data=None,
-        called_directly=True,
-    ):
-        raise NotImplementedError()
 
-    @classmethod
-    def from_dict(cls: Type[NinProofingElement], data: Dict[str, Any], raise_on_unknown: bool = True) -> NinProofingElement:
-        """
-        Construct nin proofing element from a data dict.
-        """
-        data = copy.copy(data)
-
-        self = super().from_dict(data)
-        self.number = data.pop('number')
-
-        return self
-
-    @property
-    def number(self):
-        """
-        This is the nin number.
-
-        :return: nin number.
-        :rtype: str | unicode
-        """
-        return self._data['number']
-
-    @number.setter
-    def number(self, value):
-        """
-        :param value: nin number.
-        :type value: str | unicode
-        """
-        if not isinstance(value, string_types):
-            raise UserDBValueError("Invalid 'number': {!r}".format(value))
-        self._data['number'] = str(value.lower())
-
-    def to_dict(self):
-        res = super(NinProofingElement, self).to_dict()
-        res['number'] = self.number
-        return res
+@dataclass
+class _EmailProofingElementRequired(ProofingElement):
+    """
+    """
+    email: str
 
 
-class EmailProofingElement(ProofingElement):
+@dataclass
+class EmailProofingElement(ProofingElement, _EmailProofingElementRequired):
     """
     Element for holding the state of an email proofing flow.
 
@@ -200,57 +118,9 @@ class EmailProofingElement(ProofingElement):
     :type data: dict
     """
 
-    def __init__(
-        self,
-        email=None,
-        application=None,
-        created_ts=None,
-        verified=False,
-        verification_code=None,
-        data=None,
-        called_directly=True,
-    ):
-        raise NotImplementedError()
 
-    @classmethod
-    def from_dict(cls: Type[EmailProofingElement], data: Dict[str, Any], raise_on_unknown: bool = True) -> EmailProofingElement:
-        """
-        Construct email proofing element from a data dict.
-        """
-        data = copy.copy(data)
-
-        self = super().from_dict(data)
-        self.email = data.pop('email')
-
-        return self
-
-    @property
-    def email(self):
-        """
-        This is the email.
-
-        :return: nin number.
-        :rtype: str | unicode
-        """
-        return self._data['email']
-
-    @email.setter
-    def email(self, value):
-        """
-        :param value: email.
-        :type value: str | unicode
-        """
-        if not isinstance(value, string_types):
-            raise UserDBValueError("Invalid 'email': {!r}".format(value))
-        self._data['email'] = str(value.lower())
-
-    def to_dict(self):
-        res = super(ProofingElement, self).to_dict()
-        res['email'] = self.email
-        return res
-
-
-class PhoneProofingElement(ProofingElement):
+@dataclass
+class PhoneProofingElement(ProofingElement, _NumberProofingElementRequired):
     """
     Element for holding the state of a phone number proofing flow.
 
@@ -269,56 +139,8 @@ class PhoneProofingElement(ProofingElement):
     :type data: dict
     """
 
-    def __init__(
-        self,
-        phone=None,
-        application=None,
-        created_ts=None,
-        verified=False,
-        verification_code=None,
-        data=None,
-        called_directly=True,
-    ):
-        raise NotImplementedError()
 
-    @classmethod
-    def from_dict(cls: Type[PhoneProofingElement], data: Dict[str, Any], raise_on_unknown: bool = True) -> PhoneProofingElement:
-        """
-        Construct phone proofing element from a data dict.
-        """
-        data = copy.copy(data)
-
-        self = super().from_dict(data)
-        self.number = data.pop('number')
-
-        return self
-
-    @property
-    def number(self):
-        """
-        This is the phone number.
-
-        :return: phone number.
-        :rtype: str | unicode
-        """
-        return self._data['number']
-
-    @number.setter
-    def number(self, value):
-        """
-        :param value: number.
-        :type value: str | unicode
-        """
-        if not isinstance(value, string_types):
-            raise UserDBValueError("Invalid 'phone number': {!r}".format(value))
-        self._data['number'] = str(value.lower())
-
-    def to_dict(self):
-        res = super(ProofingElement, self).to_dict()
-        res['number'] = self.number
-        return res
-
-
+@dataclass
 class SentLetterElement(Element):
     """
     Properties of SentLetterElement:
@@ -330,87 +152,7 @@ class SentLetterElement(Element):
     created_by
     created_ts
     """
-
-    def __init__(self, data, called_directly=True):
-        raise NotImplementedError()
-
-    @classmethod
-    def from_dict(cls: Type[SentLetterElement], data: Dict[str, Any], raise_on_unknown: bool = True) -> SentLetterElement:
-        """
-        Construct sent letter element from a data dict.
-        """
-        self = super().from_dict(data)
-
-        self._data['is_sent'] = data.pop('is_sent', False)
-        self._data['sent_ts'] = data.pop('sent_ts', None)
-        self._data['transaction_id'] = data.pop('transaction_id', None)
-        self._data['address'] = data.pop('address', None)
-
-        return self
-
-    @property
-    def is_sent(self):
-        """
-        :return: True if this is a verified element.
-        :rtype: bool
-        """
-        return self._data['is_sent']
-
-    @is_sent.setter
-    def is_sent(self, value):
-        """
-        :param value: New verification status
-        :type value: bool
-        """
-        if not isinstance(value, bool):
-            raise UserDBValueError("Invalid 'is_sent': {!r}".format(value))
-        self._data['is_sent'] = value
-
-    @property
-    def sent_ts(self):
-        """
-        :return: Timestamp of when letter was delivered to letter service.
-        :rtype: datetime.datetime
-        """
-        return self._data.get('sent_ts')
-
-    @sent_ts.setter
-    def sent_ts(self, value):
-        """
-        :param value: Timestamp of when letter was delivered to letter service.
-                      Value None is ignored, True is short for datetime.utcnow().
-        :type value: datetime.datetime | True | None
-        """
-        _set_something_ts(self._data, 'sent_ts', value)
-
-    @property
-    def transaction_id(self):
-        """
-        :return: Transaction information from the letter service
-        :rtype: str | unicode
-        """
-        return self._data.get('transaction_id', '')
-
-    @transaction_id.setter
-    def transaction_id(self, value):
-        """
-        :param value: Transaction information from letter service (None is no-op).
-        :type value: str | unicode | None
-        """
-        _set_something_by(self._data, 'transaction_id', value)
-
-    @property
-    def address(self):
-        """
-        :return: Official address the letter should be sent to
-        :rtype: str | unicode
-        """
-        return self._data.get('address', None)
-
-    @address.setter
-    def address(self, value):
-        """
-        :param value: Official address the letter should be sent to
-        :type value: dict | None
-        """
-        self._data['address'] = value
+    is_sent: bool = False
+    sent_ts: Optional[datetime] = None
+    transaction_id: Optional[str] = None
+    address: Optional[str] = None

--- a/src/eduid_userdb/proofing/state.py
+++ b/src/eduid_userdb/proofing/state.py
@@ -135,11 +135,6 @@ class NinProofingState(ProofingState):
         _data['nin'] = NinProofingElement.from_dict(_data['nin'])
         return cls._default_from_dict(_data, {'nin'})
 
-    def to_dict(self) -> MutableMapping:
-        res = super().to_dict()
-        res['nin'] = res['nin'].to_dict()
-        return res
-
 
 @dataclass()
 class LetterProofingState(NinProofingState):
@@ -152,11 +147,6 @@ class LetterProofingState(NinProofingState):
         _data['nin'] = NinProofingElement.from_dict(_data['nin'])
         _data['proofing_letter'] = SentLetterElement.from_dict(_data['proofing_letter'])
         return cls._default_from_dict(_data, {'nin', 'proofing_letter'})
-
-    def to_dict(self) -> MutableMapping:
-        res = super().to_dict()
-        res['proofing_letter'] = res['proofing_letter'].to_dict()
-        return res
 
 
 @dataclass()
@@ -195,11 +185,6 @@ class EmailProofingState(ProofingState):
         _data['verification'] = EmailProofingElement.from_dict(_data['verification'])
         return cls._default_from_dict(_data, {'verification'})
 
-    def to_dict(self) -> MutableMapping:
-        res = super().to_dict()
-        res['verification'] = res['verification'].to_dict()
-        return res
-
 
 @dataclass()
 class PhoneProofingState(ProofingState):
@@ -211,8 +196,3 @@ class PhoneProofingState(ProofingState):
         _data = copy.deepcopy(dict(data))  # to not modify callers data
         _data['verification'] = PhoneProofingElement.from_dict(_data['verification'])
         return cls._default_from_dict(_data, {'verification'})
-
-    def to_dict(self) -> MutableMapping:
-        res = super().to_dict()
-        res['verification'] = res['verification'].to_dict()
-        return res

--- a/src/eduid_userdb/proofing/state.py
+++ b/src/eduid_userdb/proofing/state.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 import copy
 import datetime
 from dataclasses import asdict, dataclass
-from typing import Iterable, Mapping, MutableMapping, Optional, Set
+from typing import Mapping, MutableMapping, Optional, Set
 
 import bson
 
@@ -135,6 +135,12 @@ class NinProofingState(ProofingState):
         _data['nin'] = NinProofingElement.from_dict(_data['nin'])
         return cls._default_from_dict(_data, {'nin'})
 
+    def to_dict(self) -> MutableMapping:
+        nin_data = self.nin.to_dict()
+        res = super().to_dict()
+        res['nin'] = nin_data
+        return res
+
 
 @dataclass()
 class LetterProofingState(NinProofingState):
@@ -147,6 +153,12 @@ class LetterProofingState(NinProofingState):
         _data['nin'] = NinProofingElement.from_dict(_data['nin'])
         _data['proofing_letter'] = SentLetterElement.from_dict(_data['proofing_letter'])
         return cls._default_from_dict(_data, {'nin', 'proofing_letter'})
+
+    def to_dict(self) -> MutableMapping:
+        letter_data = self.proofing_letter.to_dict()
+        res = super().to_dict()
+        res['proofing_letter'] = letter_data
+        return res
 
 
 @dataclass()
@@ -185,6 +197,12 @@ class EmailProofingState(ProofingState):
         _data['verification'] = EmailProofingElement.from_dict(_data['verification'])
         return cls._default_from_dict(_data, {'verification'})
 
+    def to_dict(self) -> MutableMapping:
+        email_data = self.verification.to_dict()
+        res = super().to_dict()
+        res['verification'] = email_data
+        return res
+
 
 @dataclass()
 class PhoneProofingState(ProofingState):
@@ -196,3 +214,9 @@ class PhoneProofingState(ProofingState):
         _data = copy.deepcopy(dict(data))  # to not modify callers data
         _data['verification'] = PhoneProofingElement.from_dict(_data['verification'])
         return cls._default_from_dict(_data, {'verification'})
+
+    def to_dict(self) -> MutableMapping:
+        phone_data = self.verification.to_dict()
+        res = super().to_dict()
+        res['verification'] = phone_data
+        return res

--- a/src/eduid_userdb/reset_password/db.py
+++ b/src/eduid_userdb/reset_password/db.py
@@ -54,7 +54,7 @@ class ResetPasswordUserDB(UserDB):
     def __init__(self, db_uri: Optional[str], db_name: str = 'eduid_reset_password', collection: str = 'profiles'):
         super(ResetPasswordUserDB, self).__init__(db_uri, db_name, collection=collection)
 
-    def save(self, user: User, check_sync: bool = True, old_format: bool = False) -> bool:
+    def save(self, user: User, check_sync: bool = True, old_format: Optional[bool] = None) -> bool:
         return super(ResetPasswordUserDB, self).save(user, check_sync=check_sync, old_format=old_format)
 
 

--- a/src/eduid_userdb/reset_password/element.py
+++ b/src/eduid_userdb/reset_password/element.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any, Dict, Mapping, Type, Union
+from typing import ClassVar, Dict, Mapping, Type, Union
 
 from eduid_userdb.element import Element
 
@@ -42,6 +42,7 @@ from eduid_userdb.element import Element
 @dataclass
 class _CodeElementRequired:
     """
+    Required fields for CodeElement
     """
     code: str
     is_verified: bool
@@ -51,7 +52,7 @@ class _CodeElementRequired:
 class CodeElement(Element, _CodeElementRequired):
     """
     """
-    name_mapping = {'verified': 'is_verified'}
+    name_mapping: ClassVar[Dict[str, str]] = {'verified': 'is_verified'}
 
     @property
     def key(self) -> str:

--- a/src/eduid_userdb/reset_password/element.py
+++ b/src/eduid_userdb/reset_password/element.py
@@ -44,6 +44,7 @@ class _CodeElementRequired:
     """
     Required fields for CodeElement
     """
+
     code: str
     is_verified: bool
 
@@ -52,6 +53,7 @@ class _CodeElementRequired:
 class CodeElement(Element, _CodeElementRequired):
     """
     """
+
     name_mapping: ClassVar[Dict[str, str]] = {'verified': 'is_verified'}
 
     @property
@@ -79,7 +81,15 @@ class CodeElement(Element, _CodeElementRequired):
         if isinstance(code_or_element, dict):
             data = code_or_element
             for this in data.keys():
-                if this not in ['application', 'code', 'created_by', 'created_ts', 'verified', 'modified_ts', 'modified_by']:
+                if this not in [
+                    'application',
+                    'code',
+                    'created_by',
+                    'created_ts',
+                    'verified',
+                    'modified_ts',
+                    'modified_by',
+                ]:
                     raise ValueError(f'Unknown data {this} for CodeElement.parse from mapping')
             return cls(
                 created_by=data.get('created_by', application),

--- a/src/eduid_userdb/reset_password/element.py
+++ b/src/eduid_userdb/reset_password/element.py
@@ -60,25 +60,25 @@ class CodeElement(Element, _CodeElementRequired):
         return self.code
 
     @classmethod
-    def _data_in_transforms(cls: Type[CodeElement], data: Dict[str, Any]) -> Dict[str, Any]:
+    def _from_dict_transform(cls: Type[CodeElement], data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Transform data received in eduid format into pythonic format.
         """
-        data = super()._data_in_transforms(data)
+        data = super()._from_dict_transform(data)
 
         if 'verified' in data:
             data['is_verified'] = data.pop('verified')
 
         return data
 
-    def _data_out_transforms(self, data: Dict[str, Any]) -> Dict[str, Any]:
+    def _to_dict_transform(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Transform data kept in pythonic format into eduid format.
         """
         if 'is_verified' in data:
             data['verified'] = data.pop('is_verified')
 
-        data = super()._data_out_transforms(data)
+        data = super()._to_dict_transform(data)
 
         return data
 

--- a/src/eduid_userdb/reset_password/element.py
+++ b/src/eduid_userdb/reset_password/element.py
@@ -51,18 +51,7 @@ class _CodeElementRequired:
 class CodeElement(Element, _CodeElementRequired):
     """
     """
-
-    @classmethod
-    def massage_data(cls: Type[CodeElement], data: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Construct locked identity element from a data dict.
-        """
-        data = super().massage_data(data)
-
-        if 'verified' in data:
-            data['is_verified'] = data.pop('verified')
-
-        return data
+    name_mapping = {'verified': 'is_verified'}
 
     @property
     def key(self) -> str:
@@ -85,17 +74,17 @@ class CodeElement(Element, _CodeElementRequired):
         cls: Type[CodeElement], code_or_element: Union[Mapping, CodeElement, str], application: str
     ) -> CodeElement:
         if isinstance(code_or_element, str):
-            return cls(application=application, code=code_or_element, created_ts=True, verified=False)
+            return cls(created_by=application, code=code_or_element, created_ts=True, is_verified=False)
         if isinstance(code_or_element, dict):
             data = code_or_element
             for this in data.keys():
-                if this not in ['application', 'code', 'created_by', 'created_ts', 'verified']:
+                if this not in ['application', 'code', 'created_by', 'created_ts', 'verified', 'modified_ts', 'modified_by']:
                     raise ValueError(f'Unknown data {this} for CodeElement.parse from mapping')
             return cls(
-                application=data.get('created_by', application),
+                created_by=data.get('created_by', application),
                 code=data['code'],
                 created_ts=data.get('created_ts', True),
-                verified=data.get('verified', False),
+                is_verified=data.get('verified', False),
             )
         if isinstance(code_or_element, CodeElement):
             return code_or_element

--- a/src/eduid_userdb/reset_password/element.py
+++ b/src/eduid_userdb/reset_password/element.py
@@ -71,14 +71,14 @@ class CodeElement(Element, _CodeElementRequired):
 
         return data
 
-    def _data_out_transforms(self, data: Dict[str, Any], old_userdb_format: bool = False) -> Dict[str, Any]:
+    def _data_out_transforms(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Transform data kept in pythonic format into eduid format.
         """
         if 'is_verified' in data:
             data['verified'] = data.pop('is_verified')
 
-        data = super()._data_out_transforms(data, old_userdb_format)
+        data = super()._data_out_transforms(data)
 
         return data
 

--- a/src/eduid_userdb/reset_password/element.py
+++ b/src/eduid_userdb/reset_password/element.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import ClassVar, Dict, Mapping, Type, Union
+from typing import Any, Dict, Mapping, Type, Union
 
 from eduid_userdb.element import Element
 
@@ -54,12 +54,33 @@ class CodeElement(Element, _CodeElementRequired):
     """
     """
 
-    name_mapping: ClassVar[Dict[str, str]] = {'verified': 'is_verified'}
-
     @property
     def key(self) -> str:
         """Get element key."""
         return self.code
+
+    @classmethod
+    def _data_in_transforms(cls: Type[CodeElement], data: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Transform data received in eduid format into pythonic format.
+        """
+        data = super()._data_in_transforms(data)
+
+        if 'verified' in data:
+            data['is_verified'] = data.pop('verified')
+
+        return data
+
+    def _data_out_transforms(self, data: Dict[str, Any], old_userdb_format: bool = False) -> Dict[str, Any]:
+        """
+        Transform data kept in pythonic format into eduid format.
+        """
+        if 'is_verified' in data:
+            data['verified'] = data.pop('is_verified')
+
+        data = super()._data_out_transforms(data, old_userdb_format)
+
+        return data
 
     def is_expired(self, timeout_seconds: int) -> bool:
         """

--- a/src/eduid_userdb/reset_password/element.py
+++ b/src/eduid_userdb/reset_password/element.py
@@ -40,7 +40,7 @@ from eduid_userdb.element import Element
 
 
 @dataclass
-class _CodeElementRequired(Element):
+class _CodeElementRequired:
     """
     """
     code: str

--- a/src/eduid_userdb/reset_password/element.py
+++ b/src/eduid_userdb/reset_password/element.py
@@ -74,7 +74,7 @@ class CodeElement(Element, _CodeElementRequired):
         cls: Type[CodeElement], code_or_element: Union[Mapping, CodeElement, str], application: str
     ) -> CodeElement:
         if isinstance(code_or_element, str):
-            return cls(created_by=application, code=code_or_element, created_ts=True, is_verified=False)
+            return cls(created_by=application, code=code_or_element, is_verified=False)
         if isinstance(code_or_element, dict):
             data = code_or_element
             for this in data.keys():
@@ -83,7 +83,7 @@ class CodeElement(Element, _CodeElementRequired):
             return cls(
                 created_by=data.get('created_by', application),
                 code=data['code'],
-                created_ts=data.get('created_ts', True),
+                created_ts=data.get('created_ts', datetime.utcnow()),
                 is_verified=data.get('verified', False),
             )
         if isinstance(code_or_element, CodeElement):

--- a/src/eduid_userdb/security/element.py
+++ b/src/eduid_userdb/security/element.py
@@ -12,6 +12,7 @@ from eduid_userdb.element import Element
 class _CodeElementRequired:
     """
     """
+
     code: str
     is_verified: bool
 
@@ -20,6 +21,7 @@ class _CodeElementRequired:
 class CodeElement(Element, _CodeElementRequired):
     """
     """
+
     name_mapping: ClassVar[Dict[str, str]] = {'verified': 'is_verified'}
 
     @property
@@ -47,7 +49,15 @@ class CodeElement(Element, _CodeElementRequired):
         if isinstance(code_or_element, dict):
             data = code_or_element
             for this in data.keys():
-                if this not in ['application', 'code', 'created_by', 'created_ts', 'verified', 'modified_ts', 'modified_by']:
+                if this not in [
+                    'application',
+                    'code',
+                    'created_by',
+                    'created_ts',
+                    'verified',
+                    'modified_ts',
+                    'modified_by',
+                ]:
                     raise ValueError(f'Unknown data {this} for CodeElement.parse from mapping')
             return cls(
                 created_by=data.get('created_by', application),

--- a/src/eduid_userdb/security/element.py
+++ b/src/eduid_userdb/security/element.py
@@ -39,14 +39,14 @@ class CodeElement(Element, _CodeElementRequired):
 
         return data
 
-    def _data_out_transforms(self, data: Dict[str, Any], old_userdb_format: bool = False) -> Dict[str, Any]:
+    def _data_out_transforms(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Transform data kept in pythonic format into eduid format.
         """
         if 'is_verified' in data:
             data['verified'] = data.pop('is_verified')
 
-        data = super()._data_out_transforms(data, old_userdb_format)
+        data = super()._data_out_transforms(data)
 
         return data
 

--- a/src/eduid_userdb/security/element.py
+++ b/src/eduid_userdb/security/element.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any, Dict, Mapping, Type, Union
+from typing import ClassVar, Dict, Mapping, Type, Union
 
 from eduid_userdb.element import Element
 
@@ -20,7 +20,7 @@ class _CodeElementRequired:
 class CodeElement(Element, _CodeElementRequired):
     """
     """
-    name_mapping = {'verified': 'is_verified'}
+    name_mapping: ClassVar[Dict[str, str]] = {'verified': 'is_verified'}
 
     @property
     def key(self) -> str:

--- a/src/eduid_userdb/security/element.py
+++ b/src/eduid_userdb/security/element.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import ClassVar, Dict, Mapping, Type, Union
+from typing import Any, Dict, Mapping, Type, Union
 
 from eduid_userdb.element import Element
 
@@ -22,12 +22,33 @@ class CodeElement(Element, _CodeElementRequired):
     """
     """
 
-    name_mapping: ClassVar[Dict[str, str]] = {'verified': 'is_verified'}
-
     @property
     def key(self) -> str:
         """Get element key."""
         return self.code
+
+    @classmethod
+    def _data_in_transforms(cls: Type[CodeElement], data: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Transform data received in eduid format into pythonic format.
+        """
+        data = super()._data_in_transforms(data)
+
+        if 'verified' in data:
+            data['is_verified'] = data.pop('verified')
+
+        return data
+
+    def _data_out_transforms(self, data: Dict[str, Any], old_userdb_format: bool = False) -> Dict[str, Any]:
+        """
+        Transform data kept in pythonic format into eduid format.
+        """
+        if 'is_verified' in data:
+            data['verified'] = data.pop('is_verified')
+
+        data = super()._data_out_transforms(data, old_userdb_format)
+
+        return data
 
     def is_expired(self, timeout_seconds: int) -> bool:
         """

--- a/src/eduid_userdb/security/element.py
+++ b/src/eduid_userdb/security/element.py
@@ -28,25 +28,25 @@ class CodeElement(Element, _CodeElementRequired):
         return self.code
 
     @classmethod
-    def _data_in_transforms(cls: Type[CodeElement], data: Dict[str, Any]) -> Dict[str, Any]:
+    def _from_dict_transform(cls: Type[CodeElement], data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Transform data received in eduid format into pythonic format.
         """
-        data = super()._data_in_transforms(data)
+        data = super()._from_dict_transform(data)
 
         if 'verified' in data:
             data['is_verified'] = data.pop('verified')
 
         return data
 
-    def _data_out_transforms(self, data: Dict[str, Any]) -> Dict[str, Any]:
+    def _to_dict_transform(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Transform data kept in pythonic format into eduid format.
         """
         if 'is_verified' in data:
             data['verified'] = data.pop('is_verified')
 
-        data = super()._data_out_transforms(data)
+        data = super()._to_dict_transform(data)
 
         return data
 

--- a/src/eduid_userdb/security/state.py
+++ b/src/eduid_userdb/security/state.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import
 
 import copy
-import datetime
 
 import bson
 from six import string_types

--- a/src/eduid_userdb/signup/user.py
+++ b/src/eduid_userdb/signup/user.py
@@ -92,8 +92,8 @@ class SignupUser(User):
                 )
             )
 
-    def to_dict(self, old_userdb_format=False):
-        res = User.to_dict(self, old_userdb_format=old_userdb_format)
+    def to_dict(self):
+        res = User.to_dict(self)
         if self._pending_mail_address is not None:
             res['pending_mail_address'] = self._pending_mail_address.to_dict()
         return res

--- a/src/eduid_userdb/testing.py
+++ b/src/eduid_userdb/testing.py
@@ -238,7 +238,7 @@ class MongoTestCase(DictTestCase):
     user = User.from_dict(mocked_user_standard.to_dict())
     mock_users_patches: list = []
 
-    def setUp(self, init_am=False, userdb_use_old_format=False, am_settings=None):
+    def setUp(self, init_am=False, am_settings=None):
         """
         Test case initialization.
 
@@ -257,7 +257,6 @@ class MongoTestCase(DictTestCase):
                     ...
 
         :param init_am: True if the test needs am
-        :param userdb_use_old_format: True if old userdb format should be used
         :param am_settings: Test specific am settings
         :return:
         """
@@ -312,7 +311,7 @@ class MongoTestCase(DictTestCase):
         for userdoc in _foo_userdb.all_userdocs():
             this = deepcopy(userdoc)  # deep-copy to not have side effects between tests
             user = User.from_dict(data=this)
-            self.amdb.save(user, check_sync=False, old_format=userdb_use_old_format)
+            self.amdb.save(user, check_sync=False, old_format=False)
 
     def tearDown(self):
         for userdoc in self.amdb._get_all_docs():

--- a/src/eduid_userdb/testing.py
+++ b/src/eduid_userdb/testing.py
@@ -45,6 +45,7 @@ import time
 import unittest
 from abc import ABC
 from copy import deepcopy
+from datetime import datetime
 from typing import Any, Dict, List, Tuple, Type
 
 import pymongo
@@ -195,10 +196,16 @@ class DictTestCase(unittest.TestCase):
     @classmethod
     def normalize_elem(cls, elem: Dict[str, Any]):
         if 'created_ts' in elem:
+            assert isinstance(elem['created_ts'], datetime)
             del elem['created_ts']
+
         if 'modified_ts' in elem:
+            assert isinstance(elem['modified_ts'], datetime)
             del elem['modified_ts']
+
         if 'verified_ts' in elem:
+            if elem['verified_ts'] is not None:
+                assert isinstance(elem['verified_ts'], datetime)
             del elem['verified_ts']
 
         if 'application' in elem:

--- a/src/eduid_userdb/testing.py
+++ b/src/eduid_userdb/testing.py
@@ -178,6 +178,7 @@ class MongoTemporaryInstance(object):
 class DictTestCase(unittest.TestCase):
     """
     """
+
     maxDiff = None
 
     @classmethod

--- a/src/eduid_userdb/testing.py
+++ b/src/eduid_userdb/testing.py
@@ -190,7 +190,7 @@ class DictTestCase(unittest.TestCase):
             for elem in elist:
                 cls.normalize_elem(elem)
 
-        return expected, obtained
+        return expected, obtained  # XXX this is useless, we are now modifying in place
 
     @classmethod
     def normalize_elem(cls, elem: Dict[str, Any]):
@@ -198,6 +198,8 @@ class DictTestCase(unittest.TestCase):
             del elem['created_ts']
         if 'modified_ts' in elem:
             del elem['modified_ts']
+        if 'verified_ts' in elem:
+            del elem['verified_ts']
 
         if 'application' in elem:
             elem['created_by'] = elem.pop('application')
@@ -211,10 +213,6 @@ class DictTestCase(unittest.TestCase):
         for key in elem:
             if isinstance(elem[key], dict):
                 cls.normalize_elem(elem[key])
-
-        for key in ('created_by', 'application', 'verified_ts', 'verified_by'):
-            if key in elem and elem[key] is None:
-                del elem[key]
 
 
 class MongoTestCase(DictTestCase):

--- a/src/eduid_userdb/testing.py
+++ b/src/eduid_userdb/testing.py
@@ -181,7 +181,7 @@ class DictTestCase(unittest.TestCase):
     maxDiff = None
 
     @classmethod
-    def normalize_data(cls, expected: List[Dict[str, Any]], obtained: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    def normalize_data(cls, expected: List[Dict[str, Any]], obtained: List[Dict[str, Any]]):
         """
         Remove timestamps that in general are created at different times
         normalize the names of some attributes
@@ -190,8 +190,6 @@ class DictTestCase(unittest.TestCase):
         for elist in (expected, obtained):
             for elem in elist:
                 cls.normalize_elem(elem)
-
-        return expected, obtained  # XXX this is useless, we are now modifying in place
 
     @classmethod
     def normalize_elem(cls, elem: Dict[str, Any]):

--- a/src/eduid_userdb/testing.py
+++ b/src/eduid_userdb/testing.py
@@ -282,3 +282,22 @@ class MongoTestCase(unittest.TestCase):
     # def mongodb_uri(self, dbname):
     #    self.assertIsNotNone(dbname)
     #    return self.tmp_db.uri + '/' + dbname
+
+
+class DictTestCase(unittest.TestCase):
+    """
+    TestCase with a compare_dicts method that compares dicts removing the
+    created_ts and modified_ts keys, that hold timestamps created in general at different times.
+    """
+
+    @staticmethod
+    def compare_dicts(expected, obtained, fail_message):
+        # Remove timestamps that are created at different times
+        for mlist in (expected, obtained):
+            for mail in mlist:
+                if 'created_ts' in mail:
+                    del mail['created_ts']
+                if 'modified_ts' in mail:
+                    del mail['modified_ts']
+
+        assert obtained == expected, fail_message

--- a/src/eduid_userdb/tests/__init__.py
+++ b/src/eduid_userdb/tests/__init__.py
@@ -42,7 +42,8 @@ class DictTestCase(unittest.TestCase):
     def normalize_data(cls, expected: List[Dict[str, Any]], obtained: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
         """
         Remove timestamps that in general are created at different times
-        and compare the resulting dicts
+        normalize the names of some attributes
+        remove attributes set to None
         """
         for elist in (expected, obtained):
             for elem in elist:
@@ -51,7 +52,7 @@ class DictTestCase(unittest.TestCase):
         return expected, obtained
 
     @classmethod
-    def normalize_elem(cls, elem: Dict[str, Any]) -> Dict[str, Any]:
+    def normalize_elem(cls, elem: Dict[str, Any]):
         if 'created_ts' in elem:
             del elem['created_ts']
         if 'modified_ts' in elem:

--- a/src/eduid_userdb/tests/__init__.py
+++ b/src/eduid_userdb/tests/__init__.py
@@ -29,48 +29,4 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 #
-import unittest
-from typing import Any, Dict, List, Tuple
-
-
-class DictTestCase(unittest.TestCase):
-    """
-    """
-    maxDiff = None
-
-    @classmethod
-    def normalize_data(cls, expected: List[Dict[str, Any]], obtained: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
-        """
-        Remove timestamps that in general are created at different times
-        normalize the names of some attributes
-        remove attributes set to None
-        """
-        for elist in (expected, obtained):
-            for elem in elist:
-                cls.normalize_elem(elem)
-
-        return expected, obtained
-
-    @classmethod
-    def normalize_elem(cls, elem: Dict[str, Any]):
-        if 'created_ts' in elem:
-            del elem['created_ts']
-        if 'modified_ts' in elem:
-            del elem['modified_ts']
-
-        if 'application' in elem:
-            elem['created_by'] = elem.pop('application')
-
-        if 'source' in elem:
-            elem['created_by'] = elem.pop('source')
-
-        if 'credential_id' in elem:
-            elem['id'] = elem.pop('credential_id')
-
-        for key in elem:
-            if isinstance(elem[key], dict):
-                cls.normalize_elem(elem[key])
-
-        for key in ('created_by', 'application', 'verified_ts', 'verified_by'):
-            if key in elem and elem[key] is None:
-                del elem[key]
+from eduid_userdb.testing import DictTestCase

--- a/src/eduid_userdb/tests/__init__.py
+++ b/src/eduid_userdb/tests/__init__.py
@@ -1,1 +1,54 @@
 #
+# Copyright (c) 2020 SUNET
+# All rights reserved.
+#
+#   Redistribution and use in source and binary forms, with or
+#   without modification, are permitted provided that the following
+#   conditions are met:
+#
+#     1. Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#     2. Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided
+#        with the distribution.
+#     3. Neither the name of the SUNET nor the names of its
+#        contributors may be used to endorse or promote products derived
+#        from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+import unittest
+from typing import Any, Dict, Tuple
+
+
+class DictTestCase(unittest.TestCase):
+    """
+    """
+    maxDiff = None
+
+    @staticmethod
+    def remove_timestamps(expected: Dict[str, Any], obtained: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        """
+        Remove timestamps that in general are created at different times
+        and compare the resulting dicts
+        """
+        for elist in (expected, obtained):
+            for elem in elist:
+                if 'created_ts' in elem:
+                    del elem['created_ts']
+                if 'modified_ts' in elem:
+                    del elem['modified_ts']
+
+        return expected, obtained

--- a/src/eduid_userdb/tests/test_credentials.py
+++ b/src/eduid_userdb/tests/test_credentials.py
@@ -64,7 +64,7 @@ class TestCredentialList(DictTestCase):
         self.assertEqual([], self.empty.to_list_of_dicts(), list)
 
         expected = [_one_dict]
-        obtained = self.one.to_list_of_dicts(old_userdb_format=True)
+        obtained = self.one.to_list_of_dicts()
 
         self.normalize_data(expected, obtained)
 

--- a/src/eduid_userdb/tests/test_credentials.py
+++ b/src/eduid_userdb/tests/test_credentials.py
@@ -66,7 +66,7 @@ class TestCredentialList(DictTestCase):
         expected = [_one_dict]
         obtained = self.one.to_list_of_dicts(old_userdb_format=True)
 
-        expected, obtained = self.normalize_data(expected, obtained)
+        self.normalize_data(expected, obtained)
 
         assert expected == obtained, 'Credential list with one password not as expected'
 
@@ -97,7 +97,7 @@ class TestCredentialList(DictTestCase):
         expected = self.two.to_list_of_dicts()
         obtained = self.one.to_list_of_dicts()
 
-        expected, obtained = self.normalize_data(expected, obtained)
+        self.normalize_data(expected, obtained)
 
         assert expected == obtained, 'List of credentials with added credential different than expected'
 
@@ -113,7 +113,7 @@ class TestCredentialList(DictTestCase):
         expected = self.three.to_list_of_dicts()
         obtained = this.to_list_of_dicts()
 
-        expected, obtained = self.normalize_data(expected, obtained)
+        self.normalize_data(expected, obtained)
 
         assert expected == obtained, 'List of credentials with added password different than expected'
 
@@ -123,7 +123,7 @@ class TestCredentialList(DictTestCase):
         expected = self.two.to_list_of_dicts()
         obtained = now_two.to_list_of_dicts()
 
-        expected, obtained = self.normalize_data(expected, obtained)
+        self.normalize_data(expected, obtained)
 
         assert expected == obtained, 'List of credentials with removed credential different than expected'
 

--- a/src/eduid_userdb/tests/test_credentials.py
+++ b/src/eduid_userdb/tests/test_credentials.py
@@ -1,11 +1,11 @@
 from hashlib import sha256
-from unittest import TestCase
 
 from bson.objectid import ObjectId
 
 import eduid_userdb.element
 import eduid_userdb.exceptions
 from eduid_userdb.credentials import U2F, CredentialList, Password
+from eduid_userdb.tests import DictTestCase
 
 __author__ = 'lundberg'
 
@@ -44,7 +44,7 @@ def _keyid(key):
     return 'sha256:' + sha256(key['keyhandle'].encode('utf-8') + key['public_key'].encode('utf-8')).hexdigest()
 
 
-class TestCredentialList(TestCase):
+class TestCredentialList(DictTestCase):
     def setUp(self):
         self.maxDiff = None  # make pytest always show full diffs
         self.empty = CredentialList([])
@@ -64,13 +64,11 @@ class TestCredentialList(TestCase):
         self.assertEqual([], self.empty.to_list_of_dicts(), list)
 
         expected = [_one_dict]
-        got = self.one.to_list_of_dicts(old_userdb_format=True)
+        obtained = self.one.to_list_of_dicts(old_userdb_format=True)
 
-        # The credential in the CredentialList has acquired a created_ts attr
-        # that is not in the original dict
-        del got[0]['created_ts']
+        expected, obtained = self.normalize_data(expected, obtained)
 
-        assert expected == got, 'Credential list with one password not as expected'
+        assert expected == obtained, 'Credential list with one password not as expected'
 
     def test_find(self):
         match = self.two.find('222222222222222222222222')
@@ -97,15 +95,11 @@ class TestCredentialList(TestCase):
         self.one.add(second)
 
         expected = self.two.to_list_of_dicts()
-        got = self.one.to_list_of_dicts()
+        obtained = self.one.to_list_of_dicts()
 
-        # The created_ts timestamps are created at slightly different times and thus differ
-        for cred in expected:
-            del cred['created_ts']
-        for cred in got:
-            del cred['created_ts']
+        expected, obtained = self.normalize_data(expected, obtained)
 
-        assert expected == got, 'List of credentials with added credential different than expected'
+        assert expected == obtained, 'List of credentials with added credential different than expected'
 
     def test_add_duplicate(self):
         dup = self.two.find(ObjectId('222222222222222222222222'))
@@ -117,29 +111,21 @@ class TestCredentialList(TestCase):
         this = CredentialList([_one_dict, _two_dict] + [third])
 
         expected = self.three.to_list_of_dicts()
-        got = this.to_list_of_dicts()
+        obtained = this.to_list_of_dicts()
 
-        # The created_ts timestamps are created at slightly different times and thus differ
-        for cred in expected:
-            del cred['created_ts']
-        for cred in got:
-            del cred['created_ts']
+        expected, obtained = self.normalize_data(expected, obtained)
 
-        assert expected == got, 'List of credentials with added password different than expected'
+        assert expected == obtained, 'List of credentials with added password different than expected'
 
     def test_remove(self):
         now_two = self.three.remove(ObjectId('333333333333333333333333'))
 
         expected = self.two.to_list_of_dicts()
-        got = now_two.to_list_of_dicts()
+        obtained = now_two.to_list_of_dicts()
 
-        # The created_ts timestamps are created at slightly different times and thus differ
-        for cred in expected:
-            del cred['created_ts']
-        for cred in got:
-            del cred['created_ts']
+        expected, obtained = self.normalize_data(expected, obtained)
 
-        assert expected == got, 'List of credentials with removed credential different than expected'
+        assert expected == obtained, 'List of credentials with removed credential different than expected'
 
     def test_remove_unknown(self):
         with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):

--- a/src/eduid_userdb/tests/test_db.py
+++ b/src/eduid_userdb/tests/test_db.py
@@ -78,8 +78,8 @@ class TestMongoDB(TestCase):
 
 
 class TestDB(MongoTestCase):
-    def setUp(self, init_am=False, userdb_use_old_format=False, am_settings=None):
-        super().setUp(init_am=init_am, userdb_use_old_format=userdb_use_old_format, am_settings=am_settings)
+    def setUp(self, init_am=False, am_settings=None):
+        super().setUp(init_am=init_am, am_settings=am_settings)
         self.doc_count = len(list(self.MockedUserDB().all_userdocs()))
 
     def test_db_count(self):

--- a/src/eduid_userdb/tests/test_element.py
+++ b/src/eduid_userdb/tests/test_element.py
@@ -26,26 +26,12 @@ class TestElements(TestCase):
         assert elem.created_ts == now
         assert isinstance(elem.modified_ts, datetime)
 
-    def test_create_element_with_created_ts_bool(self):
-        elem = Element(created_by='test', created_ts=True)
-
-        assert elem.created_by == 'test'
-        assert isinstance(elem.created_ts, datetime)
-        assert isinstance(elem.modified_ts, datetime)
-
     def test_create_element_with_modified_ts(self):
         now = datetime.utcnow()
         elem = Element(created_by='test', modified_ts=now)
 
         assert elem.created_by == 'test'
         assert elem.modified_ts == now
-        assert isinstance(elem.modified_ts, datetime)
-
-    def test_create_element_with_modified_ts_bool(self):
-        elem = Element(created_by='test', modified_ts=True)
-
-        assert elem.created_by == 'test'
-        assert isinstance(elem.modified_ts, datetime)
         assert isinstance(elem.modified_ts, datetime)
 
     def test_create_element_with_created_and_modified_ts(self):
@@ -77,7 +63,7 @@ class TestVerifiedElements(TestCase):
 
         assert elem.is_verified is False
         assert elem.verified_by is None
-        assert elem.verified_ts is False
+        assert elem.verified_ts is None
 
     def test_modify_verified_element(self):
         elem = VerifiedElement(created_by='test')
@@ -127,7 +113,7 @@ class TestPrimaryElements(TestCase):
 
         assert elem.is_verified is False
         assert elem.verified_by is None
-        assert elem.verified_ts is False
+        assert elem.verified_ts is None
 
         assert elem.is_primary is False
 

--- a/src/eduid_userdb/tests/test_element.py
+++ b/src/eduid_userdb/tests/test_element.py
@@ -5,12 +5,11 @@ from unittest import TestCase
 import bson
 
 import eduid_userdb.exceptions
-from eduid_userdb.element import Element, PrimaryElement, VerifiedElement, PrimaryElementViolation
+from eduid_userdb.element import Element, PrimaryElement, PrimaryElementViolation, VerifiedElement
 from eduid_userdb.exceptions import EduIDUserDBError, UserDBValueError, UserHasUnknownData
 
 
 class TestElements(TestCase):
-
     def test_create_element(self):
         elem = Element(created_by='test')
 
@@ -53,7 +52,6 @@ class TestElements(TestCase):
 
 
 class TestVerifiedElements(TestCase):
-
     def test_create_verified_element(self):
         elem = VerifiedElement(created_by='test')
 
@@ -85,12 +83,7 @@ class TestVerifiedElements(TestCase):
         now = datetime.utcnow()
 
         elem = VerifiedElement(
-            created_by='test',
-            created_ts=now,
-            modified_ts=now,
-            is_verified=True,
-            verified_by='test',
-            verified_ts=now
+            created_by='test', created_ts=now, modified_ts=now, is_verified=True, verified_by='test', verified_ts=now
         )
 
         assert elem.created_by == 'test'
@@ -103,7 +96,6 @@ class TestVerifiedElements(TestCase):
 
 
 class TestPrimaryElements(TestCase):
-
     def test_create_primary_element(self):
         elem = PrimaryElement(created_by='test')
 
@@ -147,7 +139,7 @@ class TestPrimaryElements(TestCase):
             is_verified=True,
             verified_by='test',
             verified_ts=now,
-            is_primary=True
+            is_primary=True,
         )
 
         assert elem.created_by == 'test'
@@ -170,7 +162,7 @@ class TestPrimaryElements(TestCase):
             is_verified=True,
             verified_by='test',
             verified_ts=now,
-            is_primary=True
+            is_primary=True,
         )
         with self.assertRaises(PrimaryElementViolation):
             elem.is_verified = False

--- a/src/eduid_userdb/tests/test_event.py
+++ b/src/eduid_userdb/tests/test_event.py
@@ -62,7 +62,6 @@ class TestEventList(TestCase):
 
         _one_dict_copy = deepcopy(_one_dict)  # Update id to event_id before comparing dicts
         _one_dict_copy['event_id'] = _one_dict_copy.pop('id')
-        _one_dict_copy['data'] = None
         self.assertEqual([_one_dict_copy], self.one.to_list_of_dicts())
 
     def test_find(self):

--- a/src/eduid_userdb/tests/test_event.py
+++ b/src/eduid_userdb/tests/test_event.py
@@ -131,10 +131,8 @@ class TestEventList(TestCase):
         el = EventList([_event_no_modified_ts])
         for event in el.to_list_of_dicts():
             self.assertIsInstance(event['modified_ts'], datetime.datetime)
-            self.assertEqual(event['modified_ts'], event['created_ts'])
         for event in el.to_list():
             self.assertIsInstance(event.modified_ts, datetime.datetime)
-            self.assertEqual(event.modified_ts, event.created_ts)
 
     def test_update_modified_ts(self):
         _event_modified_ts = {

--- a/src/eduid_userdb/tests/test_event.py
+++ b/src/eduid_userdb/tests/test_event.py
@@ -63,7 +63,7 @@ class TestEventList(TestCase):
         _one_dict_copy = deepcopy(_one_dict)  # Update id to event_id before comparing dicts
         _one_dict_copy['event_id'] = _one_dict_copy.pop('id')
         _one_dict_copy['data'] = None
-        self.assertEqual([_one_dict_copy], self.one.to_list_of_dicts(mixed_format=True))
+        self.assertEqual([_one_dict_copy], self.one.to_list_of_dicts())
 
     def test_find(self):
         match = self.one.find(self.one.to_list()[0].key)

--- a/src/eduid_userdb/tests/test_event.py
+++ b/src/eduid_userdb/tests/test_event.py
@@ -60,8 +60,9 @@ class TestEventList(TestCase):
     def test_to_list_of_dicts(self):
         self.assertEqual([], self.empty.to_list_of_dicts(), list)
 
-        _one_dict_copy = deepcopy(_one_dict)  # Update id to event_id before comparing dicts
+        _one_dict_copy = deepcopy(_one_dict)  # Update id and application to event_id before comparing dicts
         _one_dict_copy['event_id'] = _one_dict_copy.pop('id')
+        _one_dict_copy['application'] = _one_dict_copy.pop('created_by')
         self.assertEqual([_one_dict_copy], self.one.to_list_of_dicts())
 
     def test_find(self):

--- a/src/eduid_userdb/tests/test_event.py
+++ b/src/eduid_userdb/tests/test_event.py
@@ -95,7 +95,7 @@ class TestEventList(TestCase):
 
     def test_add_wrong_type(self):
         elemdict = {
-            'id': bson.ObjectId(),
+            'created_by': 'tests',
         }
         new = Element.from_dict(elemdict)
         with self.assertRaises(eduid_userdb.element.UserDBValueError):

--- a/src/eduid_userdb/tests/test_logs.py
+++ b/src/eduid_userdb/tests/test_logs.py
@@ -57,6 +57,8 @@ class TestProofingLog(TestCase):
         }
         proofing_element = TeleAdressProofing(**data)
         for key, value in data.items():
+            if key == 'eppn':
+                continue
             self.assertIn(key, proofing_element.to_dict())
             self.assertEqual(value, proofing_element.to_dict().get(key))
 
@@ -86,6 +88,8 @@ class TestProofingLog(TestCase):
         }
         proofing_element = TeleAdressProofingRelation(**data)
         for key, value in data.items():
+            if key == 'eppn':
+                continue
             self.assertIn(key, proofing_element.to_dict())
             self.assertEqual(value, proofing_element.to_dict().get(key))
 
@@ -112,6 +116,8 @@ class TestProofingLog(TestCase):
         }
         proofing_element = LetterProofing(**data)
         for key, value in data.items():
+            if key == 'eppn':
+                continue
             self.assertIn(key, proofing_element.to_dict())
             self.assertEqual(value, proofing_element.to_dict().get(key))
 
@@ -137,6 +143,8 @@ class TestProofingLog(TestCase):
         }
         proofing_element = MailAddressProofing(**data)
         for key, value in data.items():
+            if key == 'eppn':
+                continue
             self.assertIn(key, proofing_element.to_dict())
             self.assertEqual(value, proofing_element.to_dict().get(key))
 
@@ -160,6 +168,8 @@ class TestProofingLog(TestCase):
         }
         proofing_element = PhoneNumberProofing(**data)
         for key, value in data.items():
+            if key == 'eppn':
+                continue
             self.assertIn(key, proofing_element.to_dict())
             self.assertEqual(value, proofing_element.to_dict().get(key))
 
@@ -186,6 +196,8 @@ class TestProofingLog(TestCase):
         }
         proofing_element = SeLegProofing(**data)
         for key, value in data.items():
+            if key == 'eppn':
+                continue
             self.assertIn(key, proofing_element.to_dict())
             self.assertEqual(value, proofing_element.to_dict().get(key))
 
@@ -215,6 +227,8 @@ class TestProofingLog(TestCase):
         }
         proofing_element = SeLegProofingFrejaEid(**data)
         for key, value in data.items():
+            if key == 'eppn':
+                continue
             self.assertIn(key, proofing_element.to_dict())
             self.assertEqual(value, proofing_element.to_dict().get(key))
 
@@ -243,18 +257,6 @@ class TestProofingLog(TestCase):
         }
         proofing_element = PhoneNumberProofing(**data)
         proofing_element.phone_number = ''
-
-        self.assertFalse(self.proofing_log_db.save(proofing_element))
-
-    def test_missing_proofing_data(self):
-        data = {
-            'eppn': self.user.eppn,
-            'created_by': 'test',
-            'phone_number': 'some_phone_number',
-            'proofing_version': 'test',
-            'reference': 'reference id',
-        }
-        proofing_element = PhoneNumberProofing(**data)
 
         self.assertFalse(self.proofing_log_db.save(proofing_element))
 

--- a/src/eduid_userdb/tests/test_logs.py
+++ b/src/eduid_userdb/tests/test_logs.py
@@ -100,38 +100,6 @@ class TestProofingLog(TestCase):
         self.assertEqual(hit['proofing_method'], 'TeleAdress')
         self.assertEqual(hit['proofing_version'], 'test')
 
-    def test_teleadress_proofing_extend_bug(self):
-        data_match = {
-            'eppn': self.user.eppn,
-            'created_by': 'test',
-            'reason': 'matched',
-            'nin': 'some_nin',
-            'mobile_number': 'some_mobile_number',
-            'user_postal_address': {'response_data': {'some': 'data'}},
-            'proofing_version': 'test',
-        }
-
-        data_relation = {
-            'eppn': self.user.eppn,
-            'created_by': 'test',
-            'reason': 'matched_by_navet',
-            'nin': 'some_nin',
-            'mobile_number': 'some_mobile_number',
-            'user_postal_address': {'response_data': {'some': 'data'}},
-            'mobile_number_registered_to': 'registered_national_identity_number',
-            'registered_relation': 'registered_relation_to_user',
-            'registered_postal_address': {'response_data': {'some': 'data'}},
-            'proofing_version': 'test',
-        }
-
-        # Make a copy of the original required keys
-        required_keys1 = deepcopy(TeleAdressProofing(**data_match)._required_keys)
-        # Extend the required keys
-        TeleAdressProofingRelation(**data_relation)
-        # Make sure the required keys are instantiated as the original keys
-        required_keys2 = TeleAdressProofing(**data_match)._required_keys
-        self.assertEqual(required_keys1, required_keys2)
-
     def test_letter_proofing(self):
         data = {
             'eppn': self.user.eppn,
@@ -274,7 +242,7 @@ class TestProofingLog(TestCase):
             'reference': 'reference id',
         }
         proofing_element = PhoneNumberProofing(**data)
-        proofing_element._data['phone_number'] = ''
+        proofing_element.phone_number = ''
 
         self.assertFalse(self.proofing_log_db.save(proofing_element))
 
@@ -287,7 +255,6 @@ class TestProofingLog(TestCase):
             'reference': 'reference id',
         }
         proofing_element = PhoneNumberProofing(**data)
-        del proofing_element._data['created_by']
 
         self.assertFalse(self.proofing_log_db.save(proofing_element))
 
@@ -300,11 +267,11 @@ class TestProofingLog(TestCase):
             'reference': 'reference id',
         }
         proofing_element = PhoneNumberProofing(**data)
-        proofing_element._data['phone_number'] = 0
+        proofing_element.phone_number = 0
 
         self.assertTrue(self.proofing_log_db.save(proofing_element))
 
         proofing_element = PhoneNumberProofing(**data)
-        proofing_element._data['phone_number'] = False
+        proofing_element.phone_number = False
 
         self.assertTrue(self.proofing_log_db.save(proofing_element))

--- a/src/eduid_userdb/tests/test_logs.py
+++ b/src/eduid_userdb/tests/test_logs.py
@@ -33,7 +33,7 @@ class TestProofingLog(TestCase):
     def test_id_proofing_data(self):
 
         proofing_element = ProofingLogElement(
-            self.user, created_by='test', proofing_method='test', proofing_version='test'
+            eppn=self.user.eppn, created_by='test', proofing_method='test', proofing_version='test'
         )
         self.proofing_log_db.save(proofing_element)
 
@@ -47,6 +47,7 @@ class TestProofingLog(TestCase):
 
     def test_teleadress_proofing(self):
         data = {
+            'eppn': self.user.eppn,
             'created_by': 'test',
             'reason': 'matched',
             'nin': 'some_nin',
@@ -54,7 +55,7 @@ class TestProofingLog(TestCase):
             'user_postal_address': {'response_data': {'some': 'data'}},
             'proofing_version': 'test',
         }
-        proofing_element = TeleAdressProofing(self.user, **data)
+        proofing_element = TeleAdressProofing(**data)
         for key, value in data.items():
             self.assertIn(key, proofing_element.to_dict())
             self.assertEqual(value, proofing_element.to_dict().get(key))
@@ -72,6 +73,7 @@ class TestProofingLog(TestCase):
 
     def test_teleadress_proofing_relation(self):
         data = {
+            'eppn': self.user.eppn,
             'created_by': 'test',
             'reason': 'matched_by_navet',
             'nin': 'some_nin',
@@ -82,7 +84,7 @@ class TestProofingLog(TestCase):
             'registered_postal_address': {'response_data': {'some': 'data'}},
             'proofing_version': 'test',
         }
-        proofing_element = TeleAdressProofingRelation(self.user, **data)
+        proofing_element = TeleAdressProofingRelation(**data)
         for key, value in data.items():
             self.assertIn(key, proofing_element.to_dict())
             self.assertEqual(value, proofing_element.to_dict().get(key))
@@ -100,6 +102,7 @@ class TestProofingLog(TestCase):
 
     def test_teleadress_proofing_extend_bug(self):
         data_match = {
+            'eppn': self.user.eppn,
             'created_by': 'test',
             'reason': 'matched',
             'nin': 'some_nin',
@@ -109,6 +112,7 @@ class TestProofingLog(TestCase):
         }
 
         data_relation = {
+            'eppn': self.user.eppn,
             'created_by': 'test',
             'reason': 'matched_by_navet',
             'nin': 'some_nin',
@@ -121,15 +125,16 @@ class TestProofingLog(TestCase):
         }
 
         # Make a copy of the original required keys
-        required_keys1 = deepcopy(TeleAdressProofing(self.user, **data_match)._required_keys)
+        required_keys1 = deepcopy(TeleAdressProofing(**data_match)._required_keys)
         # Extend the required keys
-        TeleAdressProofingRelation(self.user, **data_relation)
+        TeleAdressProofingRelation(**data_relation)
         # Make sure the required keys are instantiated as the original keys
-        required_keys2 = TeleAdressProofing(self.user, **data_match)._required_keys
+        required_keys2 = TeleAdressProofing(**data_match)._required_keys
         self.assertEqual(required_keys1, required_keys2)
 
     def test_letter_proofing(self):
         data = {
+            'eppn': self.user.eppn,
             'created_by': 'test',
             'nin': 'some_nin',
             'letter_sent_to': {'name': {'some': 'data'}, 'address': {'some': 'data'}},
@@ -137,7 +142,7 @@ class TestProofingLog(TestCase):
             'user_postal_address': {'response_data': {'some': 'data'}},
             'proofing_version': 'test',
         }
-        proofing_element = LetterProofing(self.user, **data)
+        proofing_element = LetterProofing(**data)
         for key, value in data.items():
             self.assertIn(key, proofing_element.to_dict())
             self.assertEqual(value, proofing_element.to_dict().get(key))
@@ -156,12 +161,13 @@ class TestProofingLog(TestCase):
 
     def test_mail_address_proofing(self):
         data = {
+            'eppn': self.user.eppn,
             'created_by': 'test',
             'mail_address': 'some_mail_address',
             'proofing_version': 'test',
             'reference': 'reference id',
         }
-        proofing_element = MailAddressProofing(self.user, **data)
+        proofing_element = MailAddressProofing(**data)
         for key, value in data.items():
             self.assertIn(key, proofing_element.to_dict())
             self.assertEqual(value, proofing_element.to_dict().get(key))
@@ -178,12 +184,13 @@ class TestProofingLog(TestCase):
 
     def test_phone_number_proofing(self):
         data = {
+            'eppn': self.user.eppn,
             'created_by': 'test',
             'phone_number': 'some_phone_number',
             'proofing_version': 'test',
             'reference': 'reference id',
         }
-        proofing_element = PhoneNumberProofing(self.user, **data)
+        proofing_element = PhoneNumberProofing(**data)
         for key, value in data.items():
             self.assertIn(key, proofing_element.to_dict())
             self.assertEqual(value, proofing_element.to_dict().get(key))
@@ -201,6 +208,7 @@ class TestProofingLog(TestCase):
 
     def test_se_leg_proofing(self):
         data = {
+            'eppn': self.user.eppn,
             'created_by': 'test',
             'proofing_version': 'test',
             'nin': 'national_identity_number',
@@ -208,7 +216,7 @@ class TestProofingLog(TestCase):
             'transaction_id': 'transaction_id',
             'user_postal_address': {'response_data': {'some': 'data'}},
         }
-        proofing_element = SeLegProofing(self.user, **data)
+        proofing_element = SeLegProofing(**data)
         for key, value in data.items():
             self.assertIn(key, proofing_element.to_dict())
             self.assertEqual(value, proofing_element.to_dict().get(key))
@@ -229,6 +237,7 @@ class TestProofingLog(TestCase):
 
     def test_se_leg_proofing_freja(self):
         data = {
+            'eppn': self.user.eppn,
             'created_by': 'test',
             'proofing_version': 'test',
             'nin': 'national_identity_number',
@@ -236,7 +245,7 @@ class TestProofingLog(TestCase):
             'opaque_data': 'some data',
             'user_postal_address': {'response_data': {'some': 'data'}},
         }
-        proofing_element = SeLegProofingFrejaEid(self.user, **data)
+        proofing_element = SeLegProofingFrejaEid(**data)
         for key, value in data.items():
             self.assertIn(key, proofing_element.to_dict())
             self.assertEqual(value, proofing_element.to_dict().get(key))
@@ -258,41 +267,44 @@ class TestProofingLog(TestCase):
 
     def test_blank_string_proofing_data(self):
         data = {
+            'eppn': self.user.eppn,
             'created_by': 'test',
             'phone_number': 'some_phone_number',
             'proofing_version': 'test',
             'reference': 'reference id',
         }
-        proofing_element = PhoneNumberProofing(self.user, **data)
+        proofing_element = PhoneNumberProofing(**data)
         proofing_element._data['phone_number'] = ''
 
         self.assertFalse(self.proofing_log_db.save(proofing_element))
 
     def test_missing_proofing_data(self):
         data = {
+            'eppn': self.user.eppn,
             'created_by': 'test',
             'phone_number': 'some_phone_number',
             'proofing_version': 'test',
             'reference': 'reference id',
         }
-        proofing_element = PhoneNumberProofing(self.user, **data)
+        proofing_element = PhoneNumberProofing(**data)
         del proofing_element._data['created_by']
 
         self.assertFalse(self.proofing_log_db.save(proofing_element))
 
     def test_boolean_false_proofing_data(self):
         data = {
+            'eppn': self.user.eppn,
             'created_by': 'test',
             'phone_number': 'some_phone_number',
             'proofing_version': 'test',
             'reference': 'reference id',
         }
-        proofing_element = PhoneNumberProofing(self.user, **data)
+        proofing_element = PhoneNumberProofing(**data)
         proofing_element._data['phone_number'] = 0
 
         self.assertTrue(self.proofing_log_db.save(proofing_element))
 
-        proofing_element = PhoneNumberProofing(self.user, **data)
+        proofing_element = PhoneNumberProofing(**data)
         proofing_element._data['phone_number'] = False
 
         self.assertTrue(self.proofing_log_db.save(proofing_element))

--- a/src/eduid_userdb/tests/test_mail.py
+++ b/src/eduid_userdb/tests/test_mail.py
@@ -64,7 +64,7 @@ class TestMailAddressList(DictTestCase):
         expected = self.two.to_list_of_dicts()
         obtained = self.one.to_list_of_dicts()
 
-        expected, obtained = self.remove_timestamps(expected, obtained)
+        expected, obtained = self.normalize_data(expected, obtained)
 
         assert expected == obtained, 'Wrong data after adding mail address to list'
 
@@ -80,7 +80,7 @@ class TestMailAddressList(DictTestCase):
         expected = self.three.to_list_of_dicts()
         obtained = this.to_list_of_dicts()
 
-        expected, obtained = self.remove_timestamps(expected, obtained)
+        expected, obtained = self.normalize_data(expected, obtained)
 
         assert expected == obtained, 'Wrong data in mail address list'
 
@@ -105,7 +105,7 @@ class TestMailAddressList(DictTestCase):
         expected = self.two.to_list_of_dicts()
         obtained = now_two.to_list_of_dicts()
 
-        expected, obtained = self.remove_timestamps(expected, obtained)
+        expected, obtained = self.normalize_data(expected, obtained)
 
         assert expected == obtained, 'Wrong data after removing email from list'
 

--- a/src/eduid_userdb/tests/test_mail.py
+++ b/src/eduid_userdb/tests/test_mail.py
@@ -164,11 +164,6 @@ class TestMailAddress(TestCase):
         address = self.two.primary
         self.assertEqual(address.key, address.email)
 
-    def test_setting_invalid_mail(self):
-        this = self.one.primary
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.email = None
-
     def test_parse_cycle(self):
         """
         Tests that we output something we parsed back into the same thing we output.
@@ -176,11 +171,6 @@ class TestMailAddress(TestCase):
         for this in [self.one, self.two, self.three]:
             this_dict = this.to_list_of_dicts()
             self.assertEqual(MailAddressList(this_dict).to_list_of_dicts(), this.to_list_of_dicts())
-
-    def test_bad_is_primary(self):
-        this = self.one.to_list()[0]
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.is_primary = 'foo'
 
     def test_unknown_input_data(self):
         one = copy.deepcopy(_one_dict)
@@ -206,25 +196,16 @@ class TestMailAddress(TestCase):
         this.is_verified = False  # was False already
         this.is_verified = True
 
-    def test_setting_invalid_is_verified(self):
-        this = self.three.find('ft@three.example.org')
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.is_verified = 1
-
     def test_verified_by(self):
         this = self.three.find('ft@three.example.org')
         this.verified_by = 'unit test'
         self.assertEqual(this.verified_by, 'unit test')
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.verified_by = False
 
     def test_modify_verified_by(self):
         this = self.three.find('ft@three.example.org')
         this.verified_by = 'unit test'
         this.verified_by = None
         self.assertEqual(this.verified_by, 'unit test')
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.verified_by = False
         this.verified_by = 'test unit'
         self.assertEqual(this.verified_by, 'test unit')
 
@@ -232,15 +213,11 @@ class TestMailAddress(TestCase):
         this = self.three.find('ft@three.example.org')
         this.verified_ts = True
         self.assertIsInstance(this.verified_ts, datetime.datetime)
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.verified_ts = False
 
     def test_modify_verified_ts(self):
         this = self.three.find('ft@three.example.org')
         now = datetime.datetime.utcnow()
         this.verified_ts = now
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.verified_ts = 'not a datetime'
         this.verified_ts = True
         self.assertGreater(this.verified_ts, now)
         this.verified_ts = now
@@ -250,30 +227,8 @@ class TestMailAddress(TestCase):
         this = self.three.find('ft@three.example.org')
         this.created_by = 'unit test'
         self.assertEqual(this.created_by, 'unit test')
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_by = False
-
-    def test_modify_created_by(self):
-        this = self.three.find('ft@three.example.org')
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_by = 1
-        this.created_by = 'unit test'
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_by = None
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_by = 'test unit'
 
     def test_created_ts(self):
         this = self.three.find('ft@three.example.org')
         this.created_ts = True
         self.assertIsInstance(this.created_ts, datetime.datetime)
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_ts = False
-
-    def test_modify_created_ts(self):
-        this = self.three.find('ft@three.example.org')
-        this.created_ts = datetime.datetime.utcnow()
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_ts = None
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_ts = True

--- a/src/eduid_userdb/tests/test_mail.py
+++ b/src/eduid_userdb/tests/test_mail.py
@@ -5,6 +5,7 @@ from unittest import TestCase
 import eduid_userdb.element
 import eduid_userdb.exceptions
 from eduid_userdb.element import Element
+from eduid_userdb.tests import DictTestCase
 from eduid_userdb.mail import MailAddress, MailAddressList
 
 __author__ = 'ft'
@@ -28,25 +29,13 @@ _three_dict = {
 }
 
 
-class TestMailAddressList(TestCase):
+class TestMailAddressList(DictTestCase):
     def setUp(self):
         self.maxDiff = None
         self.empty = MailAddressList([])
         self.one = MailAddressList([_one_dict])
         self.two = MailAddressList([_one_dict, _two_dict])
         self.three = MailAddressList([_one_dict, _two_dict, _three_dict])
-
-    @staticmethod
-    def _compare_dicts(expected, obtained, fail_message):
-        # Remove timestamps that are created at different times
-        for mlist in (expected, obtained):
-            for mail in mlist:
-                if 'created_ts' in mail:
-                    del mail['created_ts']
-                if 'modified_ts' in mail:
-                    del mail['modified_ts']
-
-        assert obtained == expected, fail_message
 
     def test_init_bad_data(self):
         with self.assertRaises(eduid_userdb.element.UserDBValueError):
@@ -75,7 +64,9 @@ class TestMailAddressList(TestCase):
         expected = self.two.to_list_of_dicts()
         obtained = self.one.to_list_of_dicts()
 
-        self._compare_dicts(expected, obtained, 'Wrong data after adding mail address to list')
+        expected, obtained = self.remove_timestamps(expected, obtained)
+
+        assert expected == obtained, 'Wrong data after adding mail address to list'
 
     def test_add_duplicate(self):
         dup = self.two.find(self.two.primary.email)
@@ -89,7 +80,9 @@ class TestMailAddressList(TestCase):
         expected = self.three.to_list_of_dicts()
         obtained = this.to_list_of_dicts()
 
-        self._compare_dicts(obtained, expected, 'Wrong data in mail address list')
+        expected, obtained = self.remove_timestamps(expected, obtained)
+
+        assert expected == obtained, 'Wrong data in mail address list'
 
     def test_add_another_primary(self):
         new = eduid_userdb.mail.address_from_dict(
@@ -112,7 +105,9 @@ class TestMailAddressList(TestCase):
         expected = self.two.to_list_of_dicts()
         obtained = now_two.to_list_of_dicts()
 
-        self._compare_dicts(expected, obtained, 'Wrong data after removing email from list')
+        expected, obtained = self.remove_timestamps(expected, obtained)
+
+        assert expected == obtained, 'Wrong data after removing email from list'
 
     def test_remove_unknown(self):
         with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):

--- a/src/eduid_userdb/tests/test_mail.py
+++ b/src/eduid_userdb/tests/test_mail.py
@@ -5,8 +5,8 @@ from unittest import TestCase
 import eduid_userdb.element
 import eduid_userdb.exceptions
 from eduid_userdb.element import Element
-from eduid_userdb.tests import DictTestCase
 from eduid_userdb.mail import MailAddress, MailAddressList
+from eduid_userdb.tests import DictTestCase
 
 __author__ = 'ft'
 

--- a/src/eduid_userdb/tests/test_mail.py
+++ b/src/eduid_userdb/tests/test_mail.py
@@ -64,7 +64,7 @@ class TestMailAddressList(DictTestCase):
         expected = self.two.to_list_of_dicts()
         obtained = self.one.to_list_of_dicts()
 
-        expected, obtained = self.normalize_data(expected, obtained)
+        self.normalize_data(expected, obtained)
 
         assert expected == obtained, 'Wrong data after adding mail address to list'
 
@@ -80,7 +80,7 @@ class TestMailAddressList(DictTestCase):
         expected = self.three.to_list_of_dicts()
         obtained = this.to_list_of_dicts()
 
-        expected, obtained = self.normalize_data(expected, obtained)
+        self.normalize_data(expected, obtained)
 
         assert expected == obtained, 'Wrong data in mail address list'
 
@@ -105,7 +105,7 @@ class TestMailAddressList(DictTestCase):
         expected = self.two.to_list_of_dicts()
         obtained = now_two.to_list_of_dicts()
 
-        expected, obtained = self.normalize_data(expected, obtained)
+        self.normalize_data(expected, obtained)
 
         assert expected == obtained, 'Wrong data after removing email from list'
 

--- a/src/eduid_userdb/tests/test_nin.py
+++ b/src/eduid_userdb/tests/test_nin.py
@@ -50,13 +50,6 @@ class TestNinList(DictTestCase):
     def test_to_list_of_dicts(self):
         self.assertEqual([], self.empty.to_list_of_dicts(), list)
 
-        expected = [_one_dict]
-        obtained = self.one.to_list_of_dicts()
-
-        expected, obtained = self.remove_timestamps(expected, obtained)
-
-        assert expected == obtained, 'List of one NIN has unexpected data'
-
     def test_find(self):
         match = self.one.find('197801011234')
         self.assertIsInstance(match, Nin)
@@ -69,15 +62,11 @@ class TestNinList(DictTestCase):
         self.one.add(second)
 
         expected = self.two.to_list_of_dicts()
-        got = self.one.to_list_of_dicts()
-        # remove timestamps added at different times
-        for d in expected:
-            del d['created_ts']
-        for d in got:
-            if 'created_ts' in d:
-                del d['created_ts']
+        obtained = self.one.to_list_of_dicts()
 
-        assert expected == got, 'List with removed NIN has unexpected data'
+        expected, obtained = self.remove_timestamps(expected, obtained)
+
+        assert expected == obtained, 'List with removed NIN has unexpected data'
 
     def test_add_duplicate(self):
         dup = self.two.find(self.two.primary.number)
@@ -89,15 +78,11 @@ class TestNinList(DictTestCase):
         this = NinList([_one_dict, _two_dict, third])
 
         expected = self.three.to_list_of_dicts()
-        got = this.to_list_of_dicts()
-        # remove added timestamp
-        for d in expected:
-            del d['created_ts']
-        for d in got:
-            if 'created_ts' in d:
-                del d['created_ts']
+        obtained = this.to_list_of_dicts()
 
-        assert expected == got, 'List with added mail address has unexpected data'
+        expected, obtained = self.remove_timestamps(expected, obtained)
+
+        assert expected == obtained, 'List with added mail address has unexpected data'
 
     def test_add_another_primary(self):
         new = eduid_userdb.nin.nin_from_dict({'number': '+46700000009', 'verified': True, 'primary': True,})
@@ -116,14 +101,11 @@ class TestNinList(DictTestCase):
         now_two = self.three.remove('197803033456')
 
         expected = self.two.to_list_of_dicts()
-        got = now_two.to_list_of_dicts()
-        # remove timestamps added at different times
-        for d in expected:
-            del d['created_ts']
-        for d in got:
-            del d['created_ts']
+        obtained = now_two.to_list_of_dicts()
 
-        assert expected == got, 'List with removed NIN has unexpected data'
+        expected, obtained = self.remove_timestamps(expected, obtained)
+
+        assert expected == obtained, 'List with removed NIN has unexpected data'
 
     def test_remove_unknown(self):
         with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):

--- a/src/eduid_userdb/tests/test_nin.py
+++ b/src/eduid_userdb/tests/test_nin.py
@@ -64,7 +64,7 @@ class TestNinList(DictTestCase):
         expected = self.two.to_list_of_dicts()
         obtained = self.one.to_list_of_dicts()
 
-        expected, obtained = self.remove_timestamps(expected, obtained)
+        expected, obtained = self.normalize_data(expected, obtained)
 
         assert expected == obtained, 'List with removed NIN has unexpected data'
 
@@ -80,7 +80,7 @@ class TestNinList(DictTestCase):
         expected = self.three.to_list_of_dicts()
         obtained = this.to_list_of_dicts()
 
-        expected, obtained = self.remove_timestamps(expected, obtained)
+        expected, obtained = self.normalize_data(expected, obtained)
 
         assert expected == obtained, 'List with added mail address has unexpected data'
 
@@ -103,7 +103,7 @@ class TestNinList(DictTestCase):
         expected = self.two.to_list_of_dicts()
         obtained = now_two.to_list_of_dicts()
 
-        expected, obtained = self.remove_timestamps(expected, obtained)
+        expected, obtained = self.normalize_data(expected, obtained)
 
         assert expected == obtained, 'List with removed NIN has unexpected data'
 

--- a/src/eduid_userdb/tests/test_nin.py
+++ b/src/eduid_userdb/tests/test_nin.py
@@ -64,7 +64,7 @@ class TestNinList(DictTestCase):
         expected = self.two.to_list_of_dicts()
         obtained = self.one.to_list_of_dicts()
 
-        expected, obtained = self.normalize_data(expected, obtained)
+        self.normalize_data(expected, obtained)
 
         assert expected == obtained, 'List with removed NIN has unexpected data'
 
@@ -80,7 +80,7 @@ class TestNinList(DictTestCase):
         expected = self.three.to_list_of_dicts()
         obtained = this.to_list_of_dicts()
 
-        expected, obtained = self.normalize_data(expected, obtained)
+        self.normalize_data(expected, obtained)
 
         assert expected == obtained, 'List with added mail address has unexpected data'
 
@@ -103,7 +103,7 @@ class TestNinList(DictTestCase):
         expected = self.two.to_list_of_dicts()
         obtained = now_two.to_list_of_dicts()
 
-        expected, obtained = self.normalize_data(expected, obtained)
+        self.normalize_data(expected, obtained)
 
         assert expected == obtained, 'List with removed NIN has unexpected data'
 

--- a/src/eduid_userdb/tests/test_nin.py
+++ b/src/eduid_userdb/tests/test_nin.py
@@ -2,12 +2,11 @@ import copy
 import datetime
 from unittest import TestCase
 
-import bson
-
 import eduid_userdb.element
 import eduid_userdb.exceptions
-from eduid_userdb.credentials import Password
+from eduid_userdb.element import Element
 from eduid_userdb.nin import Nin, NinList
+from eduid_userdb.tests import DictTestCase
 
 __author__ = 'ft'
 
@@ -30,7 +29,7 @@ _three_dict = {
 }
 
 
-class TestNinList(TestCase):
+class TestNinList(DictTestCase):
     def setUp(self):
         self.maxDiff = None  # Make pytest show full diffs
         self.empty = NinList([])
@@ -52,12 +51,11 @@ class TestNinList(TestCase):
         self.assertEqual([], self.empty.to_list_of_dicts(), list)
 
         expected = [_one_dict]
-        got = self.one.to_list_of_dicts()
-        # remove added timestamps
-        for d in got:
-            del d['created_ts']
+        obtained = self.one.to_list_of_dicts()
 
-        assert expected == got, 'List of one NIN has unexpected data'
+        expected, obtained = self.remove_timestamps(expected, obtained)
+
+        assert expected == obtained, 'List of one NIN has unexpected data'
 
     def test_find(self):
         match = self.one.find('197801011234')
@@ -107,11 +105,10 @@ class TestNinList(TestCase):
             self.one.add(new)
 
     def test_add_wrong_type(self):
-        pwdict = {
-            'id': bson.ObjectId(),
-            'salt': 'foo',
+        elemdict = {
+            'created_by': 'tests',
         }
-        new = Password.from_dict(pwdict)
+        new = Element.from_dict(elemdict)
         with self.assertRaises(eduid_userdb.element.UserDBValueError):
             self.one.add(new)
 
@@ -198,11 +195,6 @@ class TestNin(TestCase):
         address = self.two.primary
         self.assertEqual(address.key, address.number)
 
-    def test_setting_invalid_mail(self):
-        this = self.one.primary
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.number = None
-
     def test_parse_cycle(self):
         """
         Tests that we output something we parsed back into the same thing we output.
@@ -210,25 +202,6 @@ class TestNin(TestCase):
         for this in [self.one, self.two, self.three]:
             this_dict = this.to_list_of_dicts()
             self.assertEqual(NinList(this_dict).to_list_of_dicts(), this.to_list_of_dicts())
-
-    def test_bad_is_primary(self):
-        this = self.one.to_list()[0]
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.is_primary = 'foo'
-
-    def test_unknown_input_data(self):
-        one = copy.deepcopy(_one_dict)
-        one['foo'] = 'bar'
-        with self.assertRaises(eduid_userdb.exceptions.UserHasUnknownData):
-            Nin.from_dict(one)
-
-    def test_unknown_input_data_allowed(self):
-        one = copy.deepcopy(_one_dict)
-        one['foo'] = 'bar'
-        addr = Nin.from_dict(one, raise_on_unknown=False)
-        out = addr.to_dict()
-        self.assertIn('foo', out)
-        self.assertEqual(out['foo'], one['foo'])
 
     def test_changing_is_verified_on_primary(self):
         this = self.one.primary
@@ -240,43 +213,20 @@ class TestNin(TestCase):
         this.is_verified = False  # was False already
         this.is_verified = True
 
-    def test_setting_invalid_is_verified(self):
-        this = self.three.find('197803033456')
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.is_verified = 1
-
     def test_verified_by(self):
         this = self.three.find('197803033456')
         this.verified_by = 'unit test'
         self.assertEqual(this.verified_by, 'unit test')
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.verified_by = False
 
     def test_modify_verified_by(self):
         this = self.three.find('197803033456')
         this.verified_by = 'unit test'
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.verified_by = False
         this.verified_by = 'test unit'
         self.assertEqual(this.verified_by, 'test unit')
-
-    def test_verified_ts(self):
-        this = self.three.find('197803033456')
-        this.verified_ts = True
-        self.assertIsInstance(this.verified_ts, datetime.datetime)
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.verified_ts = False
 
     def test_modify_verified_ts(self):
         this = self.three.find('197803033456')
         now = datetime.datetime.utcnow()
-        this.verified_ts = now
-        this.verified_ts = None
-        self.assertEqual(this.verified_ts, now)
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.verified_ts = 'not a datetime'
-        this.verified_ts = True
-        self.assertGreater(this.verified_ts, now)
         this.verified_ts = now
         self.assertEqual(this.verified_ts, now)
 
@@ -284,28 +234,13 @@ class TestNin(TestCase):
         this = self.three.find('197803033456')
         this.created_by = 'unit test'
         self.assertEqual(this.created_by, 'unit test')
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_by = False
 
     def test_modify_created_by(self):
         this = self.three.find('197803033456')
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_by = 1
         this.created_by = 'unit test'
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_by = None
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_by = 'test unit'
+
+        assert this.created_by == 'unit test'
 
     def test_created_ts(self):
         this = self.three.find('197803033456')
         self.assertIsInstance(this.created_ts, datetime.datetime)
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_ts = False
-
-    def test_modify_created_ts(self):
-        this = self.three.find('197803033456')
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_ts = None
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_ts = True

--- a/src/eduid_userdb/tests/test_orcid.py
+++ b/src/eduid_userdb/tests/test_orcid.py
@@ -33,22 +33,23 @@ token_response = {
 
 
 class TestOrcid(TestCase):
+
+    maxDiff = None
+
     def test_id_token(self):
         id_token_data = token_response['id_token']
         id_token_data['created_ts'] = True
         id_token_data['created_by'] = 'test'
-        id_token_1 = OidcIdToken.from_dict(id_token_data, raise_on_unknown=False)
-        id_token_2 = OidcIdToken.from_dict(
-            dict(
-                iss=id_token_data['iss'],
-                sub=id_token_data['sub'],
-                aud=id_token_data['aud'],
-                exp=id_token_data['exp'],
-                iat=id_token_data['iat'],
-                nonce=id_token_data['nonce'],
-                auth_time=id_token_data['auth_time'],
-                created_by='test',
-            )
+        id_token_1 = OidcIdToken.from_dict(id_token_data)
+        id_token_2 = OidcIdToken(
+            iss=id_token_data['iss'],
+            sub=id_token_data['sub'],
+            aud=id_token_data['aud'],
+            exp=id_token_data['exp'],
+            iat=id_token_data['iat'],
+            nonce=id_token_data['nonce'],
+            auth_time=id_token_data['auth_time'],
+            created_by='test',
         )
 
         self.assertIsInstance(id_token_1, OidcIdToken)
@@ -58,12 +59,11 @@ class TestOrcid(TestCase):
         dict_1 = id_token_1.to_dict()
         dict_2 = id_token_2.to_dict()
         del dict_1['created_ts']
+        del dict_1['modified_ts']
         del dict_2['created_ts']
+        del dict_2['modified_ts']
 
         self.assertEqual(dict_1, dict_2)
-
-        with self.assertRaises(eduid_userdb.exceptions.UserHasUnknownData):
-            OidcIdToken.from_dict(id_token_data)
 
         with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
             OidcIdToken.from_dict(None)
@@ -72,21 +72,19 @@ class TestOrcid(TestCase):
         id_token_data = token_response['id_token']
         id_token_data['created_ts'] = True
         id_token_data['created_by'] = 'test'
-        id_token = OidcIdToken.from_dict(token_response['id_token'], raise_on_unknown=False)
+        id_token = OidcIdToken.from_dict(token_response['id_token'])
 
         token_response['created_ts'] = True
         token_response['created_by'] = 'test'
-        oidc_authz_1 = OidcAuthorization.from_dict(token_response, raise_on_unknown=False)
-        oidc_authz_2 = OidcAuthorization.from_dict(
-            dict(
-                access_token=token_response['access_token'],
-                token_type=token_response['token_type'],
-                id_token=id_token,
-                expires_in=token_response['expires_in'],
-                refresh_token=token_response['refresh_token'],
-                created_by='test',
-                created_ts=True,
-            )
+        oidc_authz_1 = OidcAuthorization.from_dict(token_response)
+        oidc_authz_2 = OidcAuthorization(
+            access_token=token_response['access_token'],
+            token_type=token_response['token_type'],
+            id_token=id_token,
+            expires_in=token_response['expires_in'],
+            refresh_token=token_response['refresh_token'],
+            created_by='test',
+            created_ts=True,
         )
 
         self.assertIsInstance(oidc_authz_1, OidcAuthorization)
@@ -96,14 +94,15 @@ class TestOrcid(TestCase):
         dict_1 = oidc_authz_1.to_dict()
         dict_2 = oidc_authz_2.to_dict()
         del dict_1['created_ts']
+        del dict_1['modified_ts']
         del dict_1['id_token']['created_ts']
+        del dict_1['id_token']['modified_ts']
         del dict_2['created_ts']
+        del dict_2['modified_ts']
         del dict_2['id_token']['created_ts']
+        del dict_2['id_token']['modified_ts']
 
         self.assertEqual(dict_1, dict_2)
-
-        with self.assertRaises(eduid_userdb.exceptions.UserHasUnknownData):
-            OidcAuthorization.from_dict(token_response)
 
         with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
             OidcAuthorization.from_dict(None)
@@ -113,9 +112,9 @@ class TestOrcid(TestCase):
         token_response['id_token']['created_by'] = 'test'
         token_response['created_ts'] = True
         token_response['created_by'] = 'test'
-        oidc_authz = OidcAuthorization.from_dict(token_response, raise_on_unknown=False)
-        orcid_1 = Orcid.from_dict(
-            dict(id='https://op.example.org/user_orcid', oidc_authz=oidc_authz, created_by='test', verified=True)
+        oidc_authz = OidcAuthorization.from_dict(token_response)
+        orcid_1 = Orcid(
+            id='https://op.example.org/user_orcid', oidc_authz=oidc_authz, created_by='test', is_verified=True
         )
         orcid_2 = Orcid.from_dict(data=orcid_1.to_dict())
 
@@ -138,7 +137,7 @@ class TestOrcid(TestCase):
 
         self.assertEqual(dict_1, dict_2)
 
-        with self.assertRaises(eduid_userdb.exceptions.UserHasUnknownData):
+        with self.assertRaises(TypeError):
             data = orcid_1.to_dict()
             data['unknown_key'] = 'test'
             Orcid.from_dict(data)

--- a/src/eduid_userdb/tests/test_orcid.py
+++ b/src/eduid_userdb/tests/test_orcid.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 
-from unittest import TestCase
-
 import eduid_userdb.element
 import eduid_userdb.exceptions
 from eduid_userdb.orcid import OidcAuthorization, OidcIdToken, Orcid
+from eduid_userdb.testing import DictTestCase
 
 __author__ = 'lundberg'
 
@@ -32,13 +31,12 @@ token_response = {
 }
 
 
-class TestOrcid(TestCase):
+class TestOrcid(DictTestCase):
 
     maxDiff = None
 
     def test_id_token(self):
         id_token_data = token_response['id_token']
-        id_token_data['created_ts'] = True
         id_token_data['created_by'] = 'test'
         id_token_1 = OidcIdToken.from_dict(id_token_data)
         id_token_2 = OidcIdToken(
@@ -58,23 +56,19 @@ class TestOrcid(TestCase):
 
         dict_1 = id_token_1.to_dict()
         dict_2 = id_token_2.to_dict()
-        del dict_1['created_ts']
-        del dict_1['modified_ts']
-        del dict_2['created_ts']
-        del dict_2['modified_ts']
 
-        self.assertEqual(dict_1, dict_2)
+        self.normalize_data([dict_1], [dict_2])
+
+        assert dict_1 == dict_2, ''
 
         with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
             OidcIdToken.from_dict(None)
 
     def test_oidc_authz(self):
         id_token_data = token_response['id_token']
-        id_token_data['created_ts'] = True
         id_token_data['created_by'] = 'test'
         id_token = OidcIdToken.from_dict(token_response['id_token'])
 
-        token_response['created_ts'] = True
         token_response['created_by'] = 'test'
         oidc_authz_1 = OidcAuthorization.from_dict(token_response)
         oidc_authz_2 = OidcAuthorization(
@@ -84,7 +78,6 @@ class TestOrcid(TestCase):
             expires_in=token_response['expires_in'],
             refresh_token=token_response['refresh_token'],
             created_by='test',
-            created_ts=True,
         )
 
         self.assertIsInstance(oidc_authz_1, OidcAuthorization)
@@ -93,24 +86,16 @@ class TestOrcid(TestCase):
 
         dict_1 = oidc_authz_1.to_dict()
         dict_2 = oidc_authz_2.to_dict()
-        del dict_1['created_ts']
-        del dict_1['modified_ts']
-        del dict_1['id_token']['created_ts']
-        del dict_1['id_token']['modified_ts']
-        del dict_2['created_ts']
-        del dict_2['modified_ts']
-        del dict_2['id_token']['created_ts']
-        del dict_2['id_token']['modified_ts']
 
-        self.assertEqual(dict_1, dict_2)
+        self.normalize_data([dict_1], [dict_2])
+
+        assert dict_1 == dict_2, ''
 
         with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
             OidcAuthorization.from_dict(None)
 
     def test_orcid(self):
-        token_response['id_token']['created_ts'] = True
         token_response['id_token']['created_by'] = 'test'
-        token_response['created_ts'] = True
         token_response['created_by'] = 'test'
         oidc_authz = OidcAuthorization.from_dict(token_response)
         orcid_1 = Orcid(
@@ -128,14 +113,10 @@ class TestOrcid(TestCase):
 
         dict_1 = orcid_1.to_dict()
         dict_2 = orcid_2.to_dict()
-        del dict_1['created_ts']
-        del dict_1['oidc_authz']['created_ts']
-        del dict_1['oidc_authz']['id_token']['created_ts']
-        del dict_2['created_ts']
-        del dict_2['oidc_authz']['created_ts']
-        del dict_2['oidc_authz']['id_token']['created_ts']
 
-        self.assertEqual(dict_1, dict_2)
+        self.normalize_data([dict_1], [dict_2])
+
+        assert dict_1 == dict_2, ''
 
         with self.assertRaises(TypeError):
             data = orcid_1.to_dict()

--- a/src/eduid_userdb/tests/test_password.py
+++ b/src/eduid_userdb/tests/test_password.py
@@ -1,22 +1,19 @@
-import copy
 import datetime
 from unittest import TestCase
 
 from bson.objectid import ObjectId
 
-import eduid_userdb.element
-import eduid_userdb.exceptions
-from eduid_userdb.credentials import CredentialList, Password
+from eduid_userdb.credentials import CredentialList
 
 __author__ = 'lundberg'
 
 
 _one_dict = {
-    'id': ObjectId('55002741d00690878ae9b600'),
+    'id': '55002741d00690878ae9b600',
     'salt': 'firstPasswordElement',
 }
-_two_dict = {'id': ObjectId('55002741d00690878ae9b601'), 'salt': 'secondPasswordElement', 'source': 'test'}
-_three_dict = {'id': ObjectId('55002741d00690878ae9b602'), 'salt': 'thirdPasswordElement', 'source': 'test'}
+_two_dict = {'id': '55002741d00690878ae9b601', 'salt': 'secondPasswordElement', 'source': 'test'}
+_three_dict = {'id': '55002741d00690878ae9b602', 'salt': 'thirdPasswordElement', 'source': 'test'}
 
 
 class TestPassword(TestCase):
@@ -33,17 +30,6 @@ class TestPassword(TestCase):
         password = self.one.find(ObjectId('55002741d00690878ae9b600'))
         self.assertEqual(password.key, password.credential_id)
 
-    def test_setting_invalid_password(self):
-        this = self.one.find(ObjectId('55002741d00690878ae9b600'))
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.credential_id = None
-
-    def test_setting_invalid_salt(self):
-        this = self.one.find(ObjectId('55002741d00690878ae9b600'))
-        self.assertNotEqual(this, False)
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.salt = None
-
     def test_parse_cycle(self):
         """
         Tests that we output something we parsed back into the same thing we output.
@@ -52,46 +38,11 @@ class TestPassword(TestCase):
             this_dict = this.to_list_of_dicts()
             self.assertEqual(CredentialList(this_dict).to_list_of_dicts(), this.to_list_of_dicts())
 
-    def test_unknown_input_data(self):
-        one = copy.deepcopy(_one_dict)
-        one['foo'] = 'bar'
-        with self.assertRaises(eduid_userdb.exceptions.UserHasUnknownData):
-            Password.from_dict(one)
-
-    def test_unknown_input_data_allowed(self):
-        one = copy.deepcopy(_one_dict)
-        one['foo'] = 'bar'
-        addr = Password.from_dict(one, raise_on_unknown=False)
-        out = addr.to_dict()
-        self.assertIn('foo', out)
-        self.assertEqual(out['foo'], one['foo'])
-
     def test_created_by(self):
         this = self.three.find(ObjectId('55002741d00690878ae9b600'))
         this.created_by = 'unit test'
         self.assertEqual(this.created_by, 'unit test')
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_by = False
-
-    def test_modify_created_by(self):
-        this = self.three.find(ObjectId('55002741d00690878ae9b600'))
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_by = 1
-        this.created_by = 'unit test'
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_by = None
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_by = 'test unit'
 
     def test_created_ts(self):
         this = self.three.find(ObjectId('55002741d00690878ae9b600'))
         self.assertIsInstance(this.created_ts, datetime.datetime)
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_ts = False
-
-    def test_modify_created_ts(self):
-        this = self.three.find(ObjectId('55002741d00690878ae9b600'))
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_ts = None
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_ts = True

--- a/src/eduid_userdb/tests/test_phone.py
+++ b/src/eduid_userdb/tests/test_phone.py
@@ -61,8 +61,12 @@ class TestPhoneNumberList(DictTestCase):
 
         _one_dict_list = [_one_dict]
 
-        assert _one_dict_list[0]['primary'] == one_dict_list[0]['primary'], 'Created one phone list has wrong is_primary'
-        assert _one_dict_list[0]['verified'] == one_dict_list[0]['verified'], 'Created one phone list has wrong is_verified'
+        assert (
+            _one_dict_list[0]['primary'] == one_dict_list[0]['primary']
+        ), 'Created one phone list has wrong is_primary'
+        assert (
+            _one_dict_list[0]['verified'] == one_dict_list[0]['verified']
+        ), 'Created one phone list has wrong is_verified'
         assert _one_dict_list[0]['number'] == one_dict_list[0]['number'], 'Created one phone list has wrong number'
 
     def test_find(self):

--- a/src/eduid_userdb/tests/test_phone.py
+++ b/src/eduid_userdb/tests/test_phone.py
@@ -57,8 +57,7 @@ class TestPhoneNumberList(TestCase):
 
         # remove added timestamps
         one_dict_list = self.one.to_list_of_dicts()
-        for d in one_dict_list:
-            del d['created_ts']
+        self.normalize_data(one_dict_list, [])
 
         _one_dict_list = [_one_dict]
 
@@ -79,14 +78,7 @@ class TestPhoneNumberList(TestCase):
         expected = self.two.to_list_of_dicts()
         got = self.one.to_list_of_dicts()
         # remove timestamps added at different times
-        for d in expected:
-            del d['created_ts']
-            del d['modified_ts']
-        for d in got:
-            if 'created_ts' in d:
-                del d['created_ts']
-            if 'modified_ts' in d:
-                del d['modified_ts']
+        self.normalize_data(expected, got)
 
         assert expected == got, 'Adding a phone number to a list results in wrong data'
 
@@ -102,14 +94,7 @@ class TestPhoneNumberList(TestCase):
         expected = self.three.to_list_of_dicts()
         got = this.to_list_of_dicts()
         # remove timestamps added at different times
-        for d in expected:
-            del d['created_ts']
-            del d['modified_ts']
-        for d in got:
-            if 'created_ts' in d:
-                del d['created_ts']
-            if 'modified_ts' in d:
-                del d['modified_ts']
+        self.normalize_data(expected, got)
 
         assert expected == got, 'Phone number list contains wrong data'
 
@@ -131,12 +116,7 @@ class TestPhoneNumberList(TestCase):
         expected = self.two.to_list_of_dicts()
         got = now_two.to_list_of_dicts()
         # remove timestamps - added at different times
-        for d in expected:
-            del d['created_ts']
-            del d['modified_ts']
-        for d in got:
-            del d['created_ts']
-            del d['modified_ts']
+        self.normalize_data(expected, got)
 
         assert expected == got, 'Phone list has wrong data after removing phone'
 

--- a/src/eduid_userdb/tests/test_phone.py
+++ b/src/eduid_userdb/tests/test_phone.py
@@ -62,8 +62,8 @@ class TestPhoneNumberList(TestCase):
 
         _one_dict_list = [_one_dict]
 
-        assert _one_dict_list[0]['primary'] == one_dict_list[0]['is_primary'], 'Created one phone list has wrong is_primary'
-        assert _one_dict_list[0]['verified'] == one_dict_list[0]['is_verified'], 'Created one phone list has wrong is_verified'
+        assert _one_dict_list[0]['primary'] == one_dict_list[0]['primary'], 'Created one phone list has wrong is_primary'
+        assert _one_dict_list[0]['verified'] == one_dict_list[0]['verified'], 'Created one phone list has wrong is_verified'
         assert _one_dict_list[0]['number'] == one_dict_list[0]['number'], 'Created one phone list has wrong number'
 
     def test_find(self):
@@ -247,8 +247,8 @@ class TestPhoneNumber(TestCase):
         # remove added timestamp
         one_dict = one.to_dict()
 
-        assert _one_dict['primary'] == one_dict['is_primary'], 'Created phone has wrong is_primary'
-        assert _one_dict['verified'] == one_dict['is_verified'], 'Created phone has wrong is_verified'
+        assert _one_dict['primary'] == one_dict['primary'], 'Created phone has wrong is_primary'
+        assert _one_dict['verified'] == one_dict['verified'], 'Created phone has wrong is_verified'
         assert _one_dict['number'] == one_dict['number'], 'Created phone has wrong number'
 
     def test_parse_cycle(self):

--- a/src/eduid_userdb/tests/test_phone.py
+++ b/src/eduid_userdb/tests/test_phone.py
@@ -1,11 +1,11 @@
 import copy
 import datetime
-from unittest import TestCase
 
 import eduid_userdb.element
 import eduid_userdb.exceptions
 from eduid_userdb.element import Element
 from eduid_userdb.phone import PhoneNumber, PhoneNumberList
+from eduid_userdb.testing import DictTestCase
 
 __author__ = 'ft'
 
@@ -34,7 +34,7 @@ _four_dict = {
 }
 
 
-class TestPhoneNumberList(TestCase):
+class TestPhoneNumberList(DictTestCase):
     def setUp(self):
         self.empty = PhoneNumberList([])
         self.one = PhoneNumberList([_one_dict])
@@ -207,7 +207,7 @@ class TestPhoneNumberList(TestCase):
             PhoneNumberList([one])
 
 
-class TestPhoneNumber(TestCase):
+class TestPhoneNumber(DictTestCase):
     def setUp(self):
         self.empty = PhoneNumberList([])
         self.one = PhoneNumberList([_one_dict])

--- a/src/eduid_userdb/tests/test_profile.py
+++ b/src/eduid_userdb/tests/test_profile.py
@@ -14,10 +14,7 @@ OPAQUE_DATA = {'a_string': 'I am a string', 'an_int': 3, 'a_list': ['eins', 2, '
 class ProfileTest(TestCase):
     def test_create_profile(self):
         profile = Profile(
-            owner='test owner',
-            schema='test schema',
-            profile_data=OPAQUE_DATA,
-            created_by='test created_by',
+            owner='test owner', schema='test schema', profile_data=OPAQUE_DATA, created_by='test created_by',
         )
         self.assertEqual(profile.owner, 'test owner')
         self.assertEqual(profile.schema, 'test schema')
@@ -29,16 +26,10 @@ class ProfileTest(TestCase):
 
     def test_profile_list(self):
         profile = Profile(
-            owner='test owner 1',
-            schema='test schema',
-            profile_data=OPAQUE_DATA,
-            created_by='test created_by',
+            owner='test owner 1', schema='test schema', profile_data=OPAQUE_DATA, created_by='test created_by',
         )
         profile2 = Profile(
-            owner='test owner 2',
-            created_by='test created_by',
-            schema='test schema',
-            profile_data=OPAQUE_DATA,
+            owner='test owner 2', created_by='test created_by', schema='test schema', profile_data=OPAQUE_DATA,
         )
 
         profile_list = ProfileList([profile, profile2])
@@ -54,10 +45,7 @@ class ProfileTest(TestCase):
 
     def test_profile_list_owner_conflict(self):
         profile = Profile(
-            owner='test owner 1',
-            schema='test schema',
-            profile_data=OPAQUE_DATA,
-            created_by='test created_by',
+            owner='test owner 1', schema='test schema', profile_data=OPAQUE_DATA, created_by='test created_by',
         )
         profile_dict = profile.to_dict()
         profile2 = Profile.from_dict(profile_dict)

--- a/src/eduid_userdb/tests/test_profile.py
+++ b/src/eduid_userdb/tests/test_profile.py
@@ -18,7 +18,6 @@ class ProfileTest(TestCase):
             schema='test schema',
             profile_data=OPAQUE_DATA,
             created_by='test created_by',
-            created_ts=True,
         )
         self.assertEqual(profile.owner, 'test owner')
         self.assertEqual(profile.schema, 'test schema')
@@ -34,12 +33,10 @@ class ProfileTest(TestCase):
             schema='test schema',
             profile_data=OPAQUE_DATA,
             created_by='test created_by',
-            created_ts=True,
         )
         profile2 = Profile(
             owner='test owner 2',
             created_by='test created_by',
-            created_ts=True,
             schema='test schema',
             profile_data=OPAQUE_DATA,
         )
@@ -61,10 +58,9 @@ class ProfileTest(TestCase):
             schema='test schema',
             profile_data=OPAQUE_DATA,
             created_by='test created_by',
-            created_ts=True,
         )
         profile_dict = profile.to_dict()
-        profile2 = Profile(**profile_dict)
+        profile2 = Profile.from_dict(profile_dict)
 
         with self.assertRaises(DuplicateElementViolation):
             ProfileList([profile, profile2])

--- a/src/eduid_userdb/tests/test_proofing.py
+++ b/src/eduid_userdb/tests/test_proofing.py
@@ -72,20 +72,26 @@ class ProofingStateTest(TestCase):
             ),
             id=None,
             modified_ts=None,
-            proofing_letter=SentLetterElement.from_dict({}),
+            proofing_letter=SentLetterElement(),
         )
         state.proofing_letter.address = ADDRESS
         state_dict = state.to_dict()
+        _state_expected_keys = ['_id', 'eduPersonPrincipalName', 'nin', 'modified_ts', 'proofing_letter']
+        assert sorted(state_dict.keys()) == sorted(_state_expected_keys)
+
+        _nin_expected_keys = ['created_by', 'created_ts', 'number', 'verification_code', 'verified']
+        if not state.nin._no_modified_ts_in_db:
+            # When _no_modified_ts_in_db is removed from Element,
+            # 'modified_ts' should be added to _nin_expected_keys above
+            _nin_expected_keys += ['modified_ts']
+
         self.assertEqual(
-            sorted(state_dict.keys()), ['_id', 'eduPersonPrincipalName', 'modified_ts', 'nin', 'proofing_letter']
+            sorted([k for k, v in state_dict['nin'].items() if v is not None]), sorted(_nin_expected_keys),
         )
-        self.assertEqual(
-            sorted([k for k, v in state_dict['nin'].items() if v is not None]),
-            ['created_by', 'created_ts', 'modified_ts', 'number', 'verification_code', 'verified'],
-        )
+        _proofing_letter_expected_keys = ['address', 'created_ts', 'is_sent', 'modified_ts']
         self.assertEqual(
             sorted([k for k, v in state_dict['proofing_letter'].items() if v is not None]),
-            ['address', 'created_ts', 'is_sent', 'modified_ts'],
+            sorted(_proofing_letter_expected_keys),
         )
 
     def test_create_oidcproofingstate(self):

--- a/src/eduid_userdb/tests/test_proofing.py
+++ b/src/eduid_userdb/tests/test_proofing.py
@@ -75,16 +75,15 @@ class ProofingStateTest(TestCase):
             proofing_letter=SentLetterElement.from_dict({}),
         )
         state.proofing_letter.address = ADDRESS
-        x = state.proofing_letter.to_dict()
         state_dict = state.to_dict()
         self.assertEqual(
             sorted(state_dict.keys()), ['_id', 'eduPersonPrincipalName', 'modified_ts', 'nin', 'proofing_letter']
         )
         self.assertEqual(
-            sorted(state_dict['nin'].keys()), ['created_by', 'created_ts', 'number', 'verification_code', 'verified']
+            sorted([k for k, v in state_dict['nin'].items() if v is not None]), ['created_by', 'created_ts', 'modified_ts', 'number', 'verification_code', 'verified']
         )
         self.assertEqual(
-            sorted(state_dict['proofing_letter'].keys()), ['address', 'is_sent', 'sent_ts', 'transaction_id']
+            sorted([k for k, v in state_dict['proofing_letter'].items() if v is not None]), ['address', 'created_ts', 'is_sent', 'modified_ts']
         )
 
     def test_create_oidcproofingstate(self):

--- a/src/eduid_userdb/tests/test_proofing.py
+++ b/src/eduid_userdb/tests/test_proofing.py
@@ -80,10 +80,12 @@ class ProofingStateTest(TestCase):
             sorted(state_dict.keys()), ['_id', 'eduPersonPrincipalName', 'modified_ts', 'nin', 'proofing_letter']
         )
         self.assertEqual(
-            sorted([k for k, v in state_dict['nin'].items() if v is not None]), ['created_by', 'created_ts', 'modified_ts', 'number', 'verification_code', 'verified']
+            sorted([k for k, v in state_dict['nin'].items() if v is not None]),
+            ['created_by', 'created_ts', 'modified_ts', 'number', 'verification_code', 'verified'],
         )
         self.assertEqual(
-            sorted([k for k, v in state_dict['proofing_letter'].items() if v is not None]), ['address', 'created_ts', 'is_sent', 'modified_ts']
+            sorted([k for k, v in state_dict['proofing_letter'].items() if v is not None]),
+            ['address', 'created_ts', 'is_sent', 'modified_ts'],
         )
 
     def test_create_oidcproofingstate(self):

--- a/src/eduid_userdb/tests/test_tou.py
+++ b/src/eduid_userdb/tests/test_tou.py
@@ -56,11 +56,6 @@ class TestToUEvent(TestCase):
         event = self.two.to_list()[0]
         self.assertEqual(event.key, event.event_id)
 
-    def test_setting_invalid_version(self):
-        this = self.one.to_list()[0]
-        with self.assertRaises(eduid_userdb.exceptions.BadEvent):
-            this.version = None
-
     def test_parse_cycle(self):
         """
         Tests that we output something we parsed back into the same thing we output.
@@ -72,58 +67,14 @@ class TestToUEvent(TestCase):
                 eventlist_again.to_list_of_dicts(), this.to_list_of_dicts()
             )
 
-    def test_unknown_input_data(self):
-        one = copy.deepcopy(_one_dict)
-        one['foo'] = 'bar'
-        with self.assertRaises(eduid_userdb.exceptions.EventHasUnknownData):
-            ToUEvent.from_dict(one)
-
-    def test_unknown_input_data_allowed(self):
-        one = copy.deepcopy(_one_dict)
-        one['foo'] = 'bar'
-        addr = ToUEvent.from_dict(one, raise_on_unknown=False)
-        out = addr.to_dict()
-        self.assertIn('foo', out)
-        self.assertEqual(out['foo'], one['foo'])
-
     def test_created_by(self):
         this = Event.from_dict(dict(created_by=None, event_id=bson.ObjectId(), event_type='test_event'))
         this.created_by = 'unit test'
         self.assertEqual(this.created_by, 'unit test')
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_by = False
-
-    def test_created_ts_is_required(self):
-        """
-        Test that ToUEvent require created_ts, although Event does not.
-        """
-        with self.assertRaises(eduid_userdb.exceptions.BadEvent):
-            ToUEvent.from_dict(dict(created_by='unit test', created_ts=None, version='foo', event_id=bson.ObjectId()))
-
-    def test_created_ts_is_required2(self):
-        """
-        Test bad 'version'.
-        """
-        with self.assertRaises(eduid_userdb.exceptions.BadEvent):
-            ToUEvent.from_dict(dict(created_by='unit test', created_ts=True, version=False, event_id=bson.ObjectId()))
-
-    def test_modify_created_ts(self):
-        this = self.three.to_list()[-1]
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_ts = None
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_ts = True
 
     def test_event_type(self):
         this = self.one.to_list()[0]
         self.assertEqual(this.event_type, 'tou_event')
-
-    def test_bad_event_type(self):
-        this = self.one.to_list()[0]
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError) as cm:
-            this.event_type = 1
-        exc = cm.exception
-        self.assertEqual(exc.reason, "Invalid 'event_type': 1")
 
     def test_reaccept_tou(self):
         three_years = 94608000  # seconds
@@ -142,7 +93,7 @@ EPPN = 'hubba-bubba'
 class TestTouUser(TestCase):
     def test_proper_user(self):
         one = copy.deepcopy(_one_dict)
-        tou = ToUEvent.from_dict(one, raise_on_unknown=False)
+        tou = ToUEvent.from_dict(one)
         userdata = new_user_example.to_dict()
         userdata['tou'] = [tou]
         user = ToUUser.from_dict(data=userdata)
@@ -150,7 +101,7 @@ class TestTouUser(TestCase):
 
     def test_proper_new_user(self):
         one = copy.deepcopy(_one_dict)
-        tou = ToUList([ToUEvent.from_dict(one, raise_on_unknown=False)])
+        tou = ToUList([ToUEvent.from_dict(one)])
         userdata = new_user_example.to_dict()
         userid = userdata.pop('_id')
         eppn = userdata.pop('eduPersonPrincipalName')
@@ -160,7 +111,7 @@ class TestTouUser(TestCase):
 
     def test_proper_new_user_no_id(self):
         one = copy.deepcopy(_one_dict)
-        tou = ToUList([ToUEvent.from_dict(one, raise_on_unknown=False)])
+        tou = ToUList([ToUEvent.from_dict(one)])
         userdata = new_user_example.to_dict()
         passwords = CredentialList(userdata['passwords'])
         with self.assertRaises(UserMissingData):
@@ -168,7 +119,7 @@ class TestTouUser(TestCase):
 
     def test_proper_new_user_no_eppn(self):
         one = copy.deepcopy(_one_dict)
-        tou = ToUList([ToUEvent.from_dict(one, raise_on_unknown=False)])
+        tou = ToUList([ToUEvent.from_dict(one)])
         userdata = new_user_example.to_dict()
         userid = userdata.pop('_id')
         passwords = CredentialList(userdata['passwords'])
@@ -185,34 +136,16 @@ class TestTouUser(TestCase):
 
     def test_missing_eppn(self):
         one = copy.deepcopy(_one_dict)
-        tou = ToUList([ToUEvent.from_dict(one, raise_on_unknown=False)])
+        tou = ToUList([ToUEvent.from_dict(one)])
         with self.assertRaises(UserMissingData):
             ToUUser.from_dict(data=dict(tou=tou, userid=USERID))
 
     def test_missing_userid(self):
         one = copy.deepcopy(_one_dict)
-        tou = ToUEvent.from_dict(one, raise_on_unknown=False)
+        tou = ToUEvent.from_dict(one)
         with self.assertRaises(UserMissingData):
             ToUUser.from_dict(data=dict(tou=[tou], eppn=EPPN))
 
     def test_missing_tou(self):
         with self.assertRaises(UserMissingData):
             ToUUser.from_dict(data=dict(eppn=EPPN, userid=USERID))
-
-    def test_unknown_data(self):
-        one = copy.deepcopy(_one_dict)
-        tou = ToUEvent.from_dict(one, raise_on_unknown=False)
-        userdata = new_user_example.to_dict()
-        userdata['tou'] = [tou]
-        userdata['foo'] = 'bar'
-        with self.assertRaises(UserHasUnknownData):
-            ToUUser.from_dict(data=userdata)
-
-    def test_unknown_data_dont_raise(self):
-        one = copy.deepcopy(_one_dict)
-        tou = ToUEvent.from_dict(one, raise_on_unknown=False)
-        userdata = new_user_example.to_dict()
-        userdata['tou'] = [tou]
-        userdata['foo'] = 'bar'
-        user = ToUUser.from_dict(data=userdata, raise_on_unknown=False)
-        self.assertEqual(user.to_dict()['foo'], 'bar')

--- a/src/eduid_userdb/tests/test_tou.py
+++ b/src/eduid_userdb/tests/test_tou.py
@@ -63,9 +63,7 @@ class TestToUEvent(TestCase):
         for this in [self.one, self.two, self.three]:
             this_dict = this.to_list_of_dicts()
             eventlist_again = EventList(this_dict)
-            self.assertEqual(
-                eventlist_again.to_list_of_dicts(), this.to_list_of_dicts()
-            )
+            self.assertEqual(eventlist_again.to_list_of_dicts(), this.to_list_of_dicts())
 
     def test_created_by(self):
         this = Event.from_dict(dict(created_by=None, event_id=bson.ObjectId(), event_type='test_event'))

--- a/src/eduid_userdb/tests/test_tou.py
+++ b/src/eduid_userdb/tests/test_tou.py
@@ -147,3 +147,11 @@ class TestTouUser(TestCase):
     def test_missing_tou(self):
         with self.assertRaises(UserMissingData):
             ToUUser.from_dict(data=dict(eppn=EPPN, userid=USERID))
+
+    def test_to_dict(self):
+        one = copy.deepcopy(_one_dict)
+        tou = ToUEvent.from_dict(one)
+        data = tou.to_dict()
+        assert 'created_by' in data
+        assert 'application' not in data
+        assert data == one

--- a/src/eduid_userdb/tests/test_tou.py
+++ b/src/eduid_userdb/tests/test_tou.py
@@ -66,10 +66,10 @@ class TestToUEvent(TestCase):
         Tests that we output something we parsed back into the same thing we output.
         """
         for this in [self.one, self.two, self.three]:
-            this_dict = this.to_list_of_dicts(mixed_format=True)
+            this_dict = this.to_list_of_dicts()
             eventlist_again = EventList(this_dict)
             self.assertEqual(
-                eventlist_again.to_list_of_dicts(mixed_format=True), this.to_list_of_dicts(mixed_format=True)
+                eventlist_again.to_list_of_dicts(), this.to_list_of_dicts()
             )
 
     def test_unknown_input_data(self):

--- a/src/eduid_userdb/tests/test_u2f.py
+++ b/src/eduid_userdb/tests/test_u2f.py
@@ -54,11 +54,6 @@ class TestU2F(TestCase):
         this = self.one.find(_keyid(_one_dict))
         self.assertEqual(this.key, _keyid({'keyhandle': this.keyhandle, 'public_key': this.public_key,}))
 
-    def test_setting_invalid_keyhandle(self):
-        this = self.one.find(_keyid(_one_dict))
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.keyhandle = None
-
     def test_parse_cycle(self):
         """
         Tests that we output something we parsed back into the same thing we output.
@@ -70,46 +65,17 @@ class TestU2F(TestCase):
     def test_unknown_input_data(self):
         one = copy.deepcopy(_one_dict)
         one['foo'] = 'bar'
-        with self.assertRaises(eduid_userdb.exceptions.UserHasUnknownData):
+        with self.assertRaises(TypeError):
             U2F.from_dict(one)
-
-    def test_unknown_input_data_allowed(self):
-        one = copy.deepcopy(_one_dict)
-        one['foo'] = 'bar'
-        addr = U2F.from_dict(one, raise_on_unknown=False)
-        out = addr.to_dict()
-        self.assertIn('foo', out)
-        self.assertEqual(out['foo'], one['foo'])
 
     def test_created_by(self):
         this = self.three.find(_keyid(_three_dict))
         this.created_by = 'unit test'
         self.assertEqual(this.created_by, 'unit test')
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_by = False
-
-    def test_modify_created_by(self):
-        this = self.three.find(_keyid(_three_dict))
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_by = 1
-        this.created_by = 'unit test'
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_by = None
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_by = 'test unit'
 
     def test_created_ts(self):
         this = self.three.find(_keyid(_three_dict))
         self.assertIsInstance(this.created_ts, datetime.datetime)
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_ts = False
-
-    def test_modify_created_ts(self):
-        this = self.three.find(_keyid(_three_dict))
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_ts = None
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_ts = True
 
     def test_proofing_method(self):
         this = self.three.find(_keyid(_three_dict))
@@ -119,8 +85,6 @@ class TestU2F(TestCase):
         self.assertEqual(this.proofing_method, 'TEST2')
         this.proofing_method = None
         self.assertEqual(this.proofing_method, None)
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.proofing_method = False
 
     def test_proofing_version(self):
         this = self.three.find(_keyid(_three_dict))
@@ -130,5 +94,3 @@ class TestU2F(TestCase):
         self.assertEqual(this.proofing_version, 'TEST2')
         this.proofing_version = None
         self.assertEqual(this.proofing_version, None)
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.proofing_version = False

--- a/src/eduid_userdb/tests/test_user.py
+++ b/src/eduid_userdb/tests/test_user.py
@@ -1,6 +1,5 @@
 import datetime
 from hashlib import sha256
-from unittest import TestCase
 
 from bson import ObjectId
 from six import string_types
@@ -49,7 +48,7 @@ class _AbstractUserTestCase:
         expected = self.data1['passwords']
         obtained = self.user1.passwords.to_list_of_dicts(old_userdb_format=True)
 
-        expected, obtained = self.normalize_data(expected, obtained)
+        self.normalize_data(expected, obtained)
 
         assert expected == obtained
 
@@ -114,7 +113,7 @@ class _AbstractUserTestCase:
         expected = data['passwords']
         obtained = user.passwords.to_list_of_dicts(old_userdb_format=True)
 
-        expected, obtained = self.normalize_data(expected, obtained)
+        self.normalize_data(expected, obtained)
 
         assert expected == obtained
 
@@ -572,7 +571,7 @@ class _AbstractUserTestCase:
         )
         out = user.to_dict()['phone']
 
-        phone, out = self.normalize_data(phone, out)
+        self.normalize_data(phone, out)
 
         assert phone == out, 'The phone objects differ when using both phone and mobile'
 
@@ -699,7 +698,7 @@ class TestUser(DictTestCase, _AbstractUserTestCase):
         expected = self.data1['mailAliases']
         obtained = to_dict_result
 
-        expected, obtained = self.normalize_data(expected, obtained)
+        self.normalize_data(expected, obtained)
 
         assert obtained == expected
 
@@ -712,7 +711,7 @@ class TestUser(DictTestCase, _AbstractUserTestCase):
         expected = self.data2['mobile']
         obtained = to_dict_result
 
-        expected, obtained = self.normalize_data(expected, obtained)
+        self.normalize_data(expected, obtained)
 
         assert obtained == expected
 

--- a/src/eduid_userdb/tests/test_user.py
+++ b/src/eduid_userdb/tests/test_user.py
@@ -12,6 +12,7 @@ from eduid_userdb.mail import MailAddressList
 from eduid_userdb.nin import NinList
 from eduid_userdb.phone import PhoneNumberList
 from eduid_userdb.profile import Profile, ProfileList
+from eduid_userdb.tests import DictTestCase
 from eduid_userdb.tou import ToUList
 from eduid_userdb.user import User
 
@@ -45,7 +46,12 @@ class _AbstractUserTestCase:
         """
         Test that we get back a dict identical to the one we put in for old-style userdb data.
         """
-        self.assertEqual(self.user1.passwords.to_list_of_dicts(old_userdb_format=True), self.data1['passwords'])
+        expected = self.data1['passwords']
+        obtained = self.user1.passwords.to_list_of_dicts(old_userdb_format=True)
+
+        expected, obtained = self.normalize_data(expected, obtained)
+
+        assert expected == obtained
 
     def test_obsolete_attributes(self):
         """
@@ -104,7 +110,13 @@ class _AbstractUserTestCase:
         ]
         user = User.from_dict(data)
         self.assertEqual(user.surname, data['surname'])
-        self.assertEqual(user.passwords.to_list_of_dicts(), data['passwords'])
+
+        expected = data['passwords']
+        obtained = user.passwords.to_list_of_dicts(old_userdb_format=True)
+
+        expected, obtained = self.normalize_data(expected, obtained)
+
+        assert expected == obtained
 
     def test_revoked_user(self):
         """
@@ -559,9 +571,8 @@ class _AbstractUserTestCase:
             }
         )
         out = user.to_dict()['phone']
-        # remove timestamps
-        for _phone in out:
-            del _phone['created_ts']
+
+        phone, out = self.normalize_data(phone, out)
 
         assert phone == out, 'The phone objects differ when using both phone and mobile'
 
@@ -589,7 +600,7 @@ class _AbstractUserTestCase:
         self.assertEqual(new_user2.eppn, 'birub-gagoz')
 
 
-class TestUser(TestCase, _AbstractUserTestCase):
+class TestUser(DictTestCase, _AbstractUserTestCase):
     def setUp(self):
         self.data1 = {
             u'_id': ObjectId('547357c3d00690878ae9b620'),
@@ -683,17 +694,29 @@ class TestUser(TestCase, _AbstractUserTestCase):
         Test that we get back a dict identical to the one we put in for old-style userdb data.
         """
         to_dict_result = self.user1.mail_addresses.to_list_of_dicts(old_userdb_format=True)
-        self.assertEqual(to_dict_result, self.data1['mailAliases'])
+
+        expected = self.data1['mailAliases']
+        obtained = to_dict_result
+
+        expected, obtained = self.normalize_data(expected, obtained)
+
+        assert obtained == expected
 
     def test_phone_numbers(self):
         """
         Test that we get back a dict identical to the one we put in for old-style userdb data.
         """
         to_dict_result = self.user2.phone_numbers.to_list_of_dicts(old_userdb_format=True)
-        self.assertEqual(to_dict_result, self.data2['mobile'])
+
+        expected = self.data2['mobile']
+        obtained = to_dict_result
+
+        expected, obtained = self.normalize_data(expected, obtained)
+
+        assert obtained == expected
 
 
-class TestNewUser(TestCase, _AbstractUserTestCase):
+class TestNewUser(DictTestCase, _AbstractUserTestCase):
     def setUp(self):
         self._setup_user1()
         self._setup_user2()

--- a/src/eduid_userdb/tests/test_user.py
+++ b/src/eduid_userdb/tests/test_user.py
@@ -611,6 +611,7 @@ class TestUser(DictTestCase, _AbstractUserTestCase):
                     u'added_timestamp': datetime.datetime(2014, 12, 18, 11, 25, 19, 804000),
                     u'email': u'user@example.net',
                     u'verified': True,
+                    u'primary': True,
                 }
             ],
             u'passwords': [

--- a/src/eduid_userdb/tests/test_user.py
+++ b/src/eduid_userdb/tests/test_user.py
@@ -405,7 +405,7 @@ class _AbstractUserTestCase:
         self.assertFalse(user.tou.has_accepted('2', reaccept_interval=94608000))  # reaccept_interval seconds (3 years)
 
     def test_locked_identity_load(self):
-        locked_identity = {'created_by': 'test', 'created_ts': True, 'identity_type': 'nin', 'number': '197801012345'}
+        locked_identity = {'created_by': 'test', 'identity_type': 'nin', 'number': '197801012345'}
         data = self.data1
         data['locked_identity'] = [locked_identity]
         user = User.from_dict(data)
@@ -416,13 +416,12 @@ class _AbstractUserTestCase:
         self.assertIsInstance(user.locked_identity.find('nin').number, string_types)
 
     def test_locked_identity_set(self):
-        locked_identity = {'created_by': 'test', 'created_ts': True, 'identity_type': 'nin', 'number': '197801012345'}
+        locked_identity = {'created_by': 'test', 'identity_type': 'nin', 'number': '197801012345'}
         user = User.from_dict(self.data1)
         locked_nin = LockedIdentityNin.from_dict(
             dict(
                 number=locked_identity['number'],
                 created_by=locked_identity['created_by'],
-                created_ts=locked_identity['created_ts'],
             )
         )
         user.locked_identity.add(locked_nin)
@@ -435,13 +434,12 @@ class _AbstractUserTestCase:
         self.assertIsInstance(locked_nin.number, string_types)
 
     def test_locked_identity_to_dict(self):
-        locked_identity = {'created_by': 'test', 'created_ts': True, 'identity_type': 'nin', 'number': '197801012345'}
+        locked_identity = {'created_by': 'test', 'identity_type': 'nin', 'number': '197801012345'}
         user = User.from_dict(self.data1)
         locked_nin = LockedIdentityNin.from_dict(
             dict(
                 number=locked_identity['number'],
                 created_by=locked_identity['created_by'],
-                created_ts=locked_identity['created_ts'],
             )
         )
         user.locked_identity.add(locked_nin)
@@ -461,13 +459,12 @@ class _AbstractUserTestCase:
         self.assertIsInstance(new_user.locked_identity.to_list()[0].number, string_types)
 
     def test_locked_identity_remove(self):
-        locked_identity = {'created_by': 'test', 'created_ts': True, 'identity_type': 'nin', 'number': '197801012345'}
+        locked_identity = {'created_by': 'test', 'identity_type': 'nin', 'number': '197801012345'}
         user = User.from_dict(self.data1)
         locked_nin = LockedIdentityNin.from_dict(
             dict(
                 number=locked_identity['number'],
                 created_by=locked_identity['created_by'],
-                created_ts=locked_identity['created_ts'],
             )
         )
         user.locked_identity.add(locked_nin)

--- a/src/eduid_userdb/tests/test_user.py
+++ b/src/eduid_userdb/tests/test_user.py
@@ -430,10 +430,7 @@ class _AbstractUserTestCase:
         locked_identity = {'created_by': 'test', 'identity_type': 'nin', 'number': '197801012345'}
         user = User.from_dict(self.data1)
         locked_nin = LockedIdentityNin.from_dict(
-            dict(
-                number=locked_identity['number'],
-                created_by=locked_identity['created_by'],
-            )
+            dict(number=locked_identity['number'], created_by=locked_identity['created_by'],)
         )
         user.locked_identity.add(locked_nin)
         self.assertEqual(user.locked_identity.count, 1)
@@ -448,10 +445,7 @@ class _AbstractUserTestCase:
         locked_identity = {'created_by': 'test', 'identity_type': 'nin', 'number': '197801012345'}
         user = User.from_dict(self.data1)
         locked_nin = LockedIdentityNin.from_dict(
-            dict(
-                number=locked_identity['number'],
-                created_by=locked_identity['created_by'],
-            )
+            dict(number=locked_identity['number'], created_by=locked_identity['created_by'],)
         )
         user.locked_identity.add(locked_nin)
 
@@ -473,10 +467,7 @@ class _AbstractUserTestCase:
         locked_identity = {'created_by': 'test', 'identity_type': 'nin', 'number': '197801012345'}
         user = User.from_dict(self.data1)
         locked_nin = LockedIdentityNin.from_dict(
-            dict(
-                number=locked_identity['number'],
-                created_by=locked_identity['created_by'],
-            )
+            dict(number=locked_identity['number'], created_by=locked_identity['created_by'],)
         )
         user.locked_identity.add(locked_nin)
         with self.assertRaises(EduIDUserDBError):
@@ -553,12 +544,7 @@ class _AbstractUserTestCase:
         """ Test user that has both 'mobile' and 'phone' """
         phone = [
             {'number': '+4673123', 'primary': True, 'verified': True},
-            {
-                'created_by': 'phone',
-                'number': '+4670999',
-                'primary': False,
-                'verified': False,
-            },
+            {'created_by': 'phone', 'number': '+4670999', 'primary': False, 'verified': False,},
         ]
         user = User.from_dict(
             data={

--- a/src/eduid_userdb/tests/test_user.py
+++ b/src/eduid_userdb/tests/test_user.py
@@ -46,7 +46,7 @@ class _AbstractUserTestCase:
         Test that we get back a dict identical to the one we put in for old-style userdb data.
         """
         expected = self.data1['passwords']
-        obtained = self.user1.passwords.to_list_of_dicts(old_userdb_format=True)
+        obtained = self.user1.passwords.to_list_of_dicts()
 
         self.normalize_data(expected, obtained)
 
@@ -65,7 +65,7 @@ class _AbstractUserTestCase:
         self.assertEqual(self.user1._data, user._data)
 
         data = self.data2
-        data['mobile'][0]['verification_code'] = '123456789'
+        data['phone'][0]['verification_code'] = '123456789'
         user = User.from_dict(data)
         self.assertEqual(self.user2._data, user._data)
 
@@ -111,7 +111,7 @@ class _AbstractUserTestCase:
         self.assertEqual(user.surname, data['surname'])
 
         expected = data['passwords']
-        obtained = user.passwords.to_list_of_dicts(old_userdb_format=True)
+        obtained = user.passwords.to_list_of_dicts()
 
         self.normalize_data(expected, obtained)
 
@@ -224,15 +224,6 @@ class _AbstractUserTestCase:
         d1 = self.user1.to_dict()
         u2 = User.from_dict(d1)
         d2 = u2.to_dict()
-        self.assertEqual(d1, d2)
-
-    def test_to_dict_old_format(self):
-        """
-        Test that User objects can be recreated.
-        """
-        d1 = self.user1.to_dict(old_userdb_format=True)
-        u2 = User.from_dict(d1)
-        d2 = u2.to_dict(old_userdb_format=True)
         self.assertEqual(d1, d2)
 
     def test_modified_ts(self):
@@ -449,14 +440,14 @@ class _AbstractUserTestCase:
         )
         user.locked_identity.add(locked_nin)
 
-        old_user = User.from_dict(user.to_dict(old_userdb_format=True))
+        old_user = User.from_dict(user.to_dict())
         self.assertEqual(user.locked_identity.count, 1)
         self.assertIsInstance(old_user.locked_identity.to_list()[0].created_by, string_types)
         self.assertIsInstance(old_user.locked_identity.to_list()[0].created_ts, datetime.datetime)
         self.assertIsInstance(old_user.locked_identity.to_list()[0].identity_type, string_types)
         self.assertIsInstance(old_user.locked_identity.to_list()[0].number, string_types)
 
-        new_user = User.from_dict(user.to_dict(old_userdb_format=False))
+        new_user = User.from_dict(user.to_dict())
         self.assertEqual(user.locked_identity.count, 1)
         self.assertIsInstance(new_user.locked_identity.to_list()[0].created_by, string_types)
         self.assertIsInstance(new_user.locked_identity.to_list()[0].created_ts, datetime.datetime)
@@ -500,7 +491,7 @@ class _AbstractUserTestCase:
         user = User.from_dict(self.data1)
         user.orcid = orcid_element
 
-        old_user = User.from_dict(user.to_dict(old_userdb_format=True))
+        old_user = User.from_dict(user.to_dict())
         self.assertIsNotNone(old_user.orcid)
         self.assertIsInstance(old_user.orcid.created_by, string_types)
         self.assertIsInstance(old_user.orcid.created_ts, datetime.datetime)
@@ -508,7 +499,7 @@ class _AbstractUserTestCase:
         self.assertIsInstance(old_user.orcid.oidc_authz, OidcAuthorization)
         self.assertIsInstance(old_user.orcid.oidc_authz.id_token, OidcIdToken)
 
-        new_user = User.from_dict(user.to_dict(old_userdb_format=False))
+        new_user = User.from_dict(user.to_dict())
         self.assertIsNotNone(new_user.orcid)
         self.assertIsInstance(new_user.orcid.created_by, string_types)
         self.assertIsInstance(new_user.orcid.created_ts, datetime.datetime)
@@ -629,10 +620,10 @@ class TestUser(DictTestCase, _AbstractUserTestCase):
                     u'verified': True,
                 },
             ],
-            u'mobile': [
+            u'phone': [
                 {
-                    u'added_timestamp': datetime.datetime(2014, 12, 18, 9, 11, 35, 78000),
-                    u'mobile': u'+46702222222',
+                    u'created_ts': datetime.datetime(2014, 12, 18, 9, 11, 35, 78000),
+                    u'number': u'+46702222222',
                     u'primary': True,
                     u'verified': True,
                 }
@@ -675,26 +666,13 @@ class TestUser(DictTestCase, _AbstractUserTestCase):
         }
         self.user2 = User.from_dict(self.data2)
 
-    def test_mail_addresses_to_old_userdb_format(self):
-        """
-        Test that we get back a dict identical to the one we put in for old-style userdb data.
-        """
-        to_dict_result = self.user1.mail_addresses.to_list_of_dicts(old_userdb_format=True)
-
-        expected = self.data1['mailAliases']
-        obtained = to_dict_result
-
-        self.normalize_data(expected, obtained)
-
-        assert obtained == expected
-
     def test_phone_numbers(self):
         """
         Test that we get back a dict identical to the one we put in for old-style userdb data.
         """
-        to_dict_result = self.user2.phone_numbers.to_list_of_dicts(old_userdb_format=True)
+        to_dict_result = self.user2.phone_numbers.to_list_of_dicts()
 
-        expected = self.data2['mobile']
+        expected = self.data2['phone']
         obtained = to_dict_result
 
         self.normalize_data(expected, obtained)
@@ -851,7 +829,7 @@ class TestNewUser(DictTestCase, _AbstractUserTestCase):
             'givenName': given_name,
             'mail': mail,
             'mailAliases': mail_addresses.to_list_of_dicts(),
-            'mobile': phone_numbers.to_list_of_dicts(),
+            'phone': phone_numbers.to_list_of_dicts(),
             'passwords': passwords.to_list_of_dicts(),
             'profiles': profiles.to_list_of_dicts(),
             'preferredLanguage': language,
@@ -871,7 +849,7 @@ class TestNewUser(DictTestCase, _AbstractUserTestCase):
         Test that we get back a dict identical to the one we put in for old-style userdb data.
         """
         to_dict_result = self.user2.phone_numbers.to_list_of_dicts()
-        self.assertEqual(to_dict_result, self.data2['mobile'])
+        self.assertEqual(to_dict_result, self.data2['phone'])
 
     def test_passwords_new_format(self):
         """

--- a/src/eduid_userdb/tests/test_userdb.py
+++ b/src/eduid_userdb/tests/test_userdb.py
@@ -30,8 +30,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
-from datetime import datetime
-
 import bson
 
 import eduid_userdb
@@ -61,15 +59,7 @@ class TestUserDB(MongoTestCase):
         """ Test get_user_by_nin """
         test_user = self.amdb.get_user_by_id(self.user.user_id)
         test_user.given_name = 'Kalle Anka'
-        self.amdb.save(test_user, old_format=False)
-        res = self.amdb.get_user_by_nin(test_user.nins.primary.number)
-        self.assertEqual(test_user.given_name, res.given_name)
-
-    def test_get_user_by_nin_old_format(self):
-        """ Test get_user_by_nin old format """
-        test_user = self.amdb.get_user_by_id(self.user.user_id)
-        test_user.given_name = 'Kalle Anka 2'
-        self.amdb.save(test_user, old_format=True)
+        self.amdb.save(test_user)
         res = self.amdb.get_user_by_nin(test_user.nins.primary.number)
         self.assertEqual(test_user.given_name, res.given_name)
 
@@ -193,26 +183,6 @@ class TestUserDB_phone(MongoTestCase):
         res = self.amdb.get_user_by_phone(u'+33333333333', include_unconfirmed=True)
         self.assertEqual(self.user2.user_id, res.user_id)
 
-    def test_get_user_by_phone_old_format(self):
-        """ Test compatibility code locating old style users """
-        # Re-save the test users in old userdb format
-        user1 = self.amdb.get_user_by_id(self.user1.user_id)
-        user2 = self.amdb.get_user_by_id(self.user2.user_id)
-        self.amdb.save(user1, old_format=True)
-        self.amdb.save(user2, old_format=True)
-
-        test_user = self.amdb.get_user_by_id(self.user1.user_id)
-        res = self.amdb.get_user_by_phone(test_user.phone_numbers.primary.number)
-        self.assertEqual(test_user.user_id, res.user_id)
-
-        res = self.amdb.get_user_by_phone('+22222222222')
-        self.assertEqual(test_user.user_id, res.user_id)
-
-        self.assertIsNone(self.amdb.get_user_by_phone(u'+33333333333', raise_on_missing=False))
-
-        res = self.amdb.get_user_by_phone(u'+33333333333', include_unconfirmed=True)
-        self.assertEqual(self.user2.user_id, res.user_id)
-
     def test_get_user_by_phone_unknown(self):
         """ Test searching for unknown e-phone address """
         with self.assertRaises(eduid_userdb.exceptions.UserDoesNotExist):
@@ -279,27 +249,6 @@ class TestUserDB_nin(MongoTestCase):
 
         res = self.amdb.get_user_by_nin(u'33333333333', include_unconfirmed=True)
         self.assertEqual(self.user2.user_id, res.user_id)
-
-    def test_get_user_by_nin_old_format(self):
-        """ Test compatibility code locating old style users """
-        # Re-save the test users in old userdb format
-        user1 = self.amdb.get_user_by_id(self.user1.user_id)
-        user2 = self.amdb.get_user_by_id(self.user2.user_id)
-        self.amdb.save(user1, old_format=True)
-        self.amdb.save(user2, old_format=True)
-
-        test_user = self.amdb.get_user_by_id(self.user1.user_id)
-        res = self.amdb.get_user_by_nin(test_user.nins.primary.number)
-        self.assertEqual(test_user.user_id, res.user_id)
-
-        res = self.amdb.get_user_by_nin('22222222222')
-        self.assertEqual(self.user2.user_id, res.user_id)
-
-        self.assertIsNone(self.amdb.get_user_by_nin(u'33333333333', raise_on_missing=False))
-
-        with self.assertRaises(eduid_userdb.exceptions.UserDoesNotExist):
-            # in old userdb format, unconfirmed nins are not saved on the user
-            self.amdb.get_user_by_nin(u'33333333333', include_unconfirmed=True)
 
     def test_get_user_by_nin_unknown(self):
         """ Test searching for unknown e-nin address """

--- a/src/eduid_userdb/tests/test_webauthn.py
+++ b/src/eduid_userdb/tests/test_webauthn.py
@@ -1,11 +1,8 @@
-import copy
 import datetime
 from hashlib import sha256
 from unittest import TestCase
 
-import eduid_userdb.element
-import eduid_userdb.exceptions
-from eduid_userdb.credentials import CredentialList, Webauthn
+from eduid_userdb.credentials import CredentialList
 
 __author__ = 'lundberg'
 

--- a/src/eduid_userdb/tests/test_webauthn.py
+++ b/src/eduid_userdb/tests/test_webauthn.py
@@ -56,11 +56,6 @@ class TestWebauthn(TestCase):
             ),
         )
 
-    def test_setting_invalid_keyhandle(self):
-        this = self.one.find(_keyid(_one_dict))
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.keyhandle = None
-
     def test_parse_cycle(self):
         """
         Tests that we output something we parsed back into the same thing we output.
@@ -69,49 +64,14 @@ class TestWebauthn(TestCase):
             this_dict = this.to_list_of_dicts()
             self.assertEqual(CredentialList(this_dict).to_list_of_dicts(), this.to_list_of_dicts())
 
-    def test_unknown_input_data(self):
-        one = copy.deepcopy(_one_dict)
-        one['foo'] = 'bar'
-        with self.assertRaises(eduid_userdb.exceptions.UserHasUnknownData):
-            Webauthn.from_dict(one)
-
-    def test_unknown_input_data_allowed(self):
-        one = copy.deepcopy(_one_dict)
-        one['foo'] = 'bar'
-        addr = Webauthn.from_dict(one, raise_on_unknown=False)
-        out = addr.to_dict()
-        self.assertIn('foo', out)
-        self.assertEqual(out['foo'], one['foo'])
-
     def test_created_by(self):
         this = self.three.find(_keyid(_three_dict))
         this.created_by = 'unit test'
         self.assertEqual(this.created_by, 'unit test')
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_by = False
-
-    def test_modify_created_by(self):
-        this = self.three.find(_keyid(_three_dict))
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_by = 1
-        this.created_by = 'unit test'
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_by = None
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_by = 'test unit'
 
     def test_created_ts(self):
         this = self.three.find(_keyid(_three_dict))
         self.assertIsInstance(this.created_ts, datetime.datetime)
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_ts = False
-
-    def test_modify_created_ts(self):
-        this = self.three.find(_keyid(_three_dict))
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_ts = None
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.created_ts = True
 
     def test_proofing_method(self):
         this = self.three.find(_keyid(_three_dict))
@@ -121,8 +81,6 @@ class TestWebauthn(TestCase):
         self.assertEqual(this.proofing_method, 'TEST2')
         this.proofing_method = None
         self.assertEqual(this.proofing_method, None)
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.proofing_method = False
 
     def test_proofing_version(self):
         this = self.three.find(_keyid(_three_dict))
@@ -132,5 +90,3 @@ class TestWebauthn(TestCase):
         self.assertEqual(this.proofing_version, 'TEST2')
         this.proofing_version = None
         self.assertEqual(this.proofing_version, None)
-        with self.assertRaises(eduid_userdb.exceptions.UserDBValueError):
-            this.proofing_version = False

--- a/src/eduid_userdb/tou.py
+++ b/src/eduid_userdb/tou.py
@@ -52,10 +52,10 @@ class ToUEvent(Event):
     version: Optional[str] = None
 
     @classmethod
-    def data_in_transforms(cls: Type[ToUEvent], data: Dict[str, Any]) -> Dict[str, Any]:
+    def _data_in_transforms(cls: Type[ToUEvent], data: Dict[str, Any]) -> Dict[str, Any]:
         """
         """
-        data = super().data_in_transforms(data)
+        data = super()._data_in_transforms(data)
 
         data['event_type'] = 'tou_event'
 

--- a/src/eduid_userdb/tou.py
+++ b/src/eduid_userdb/tou.py
@@ -34,8 +34,8 @@
 #
 from __future__ import annotations
 
-from dataclasses import dataclass
 import datetime
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Type
 
 from eduid_userdb.event import Event, EventList
@@ -47,6 +47,7 @@ class ToUEvent(Event):
     """
     A record of a user's acceptance of a particular version of the Terms of Use.
     """
+
     created_by: str
     version: Optional[str] = None
 

--- a/src/eduid_userdb/tou.py
+++ b/src/eduid_userdb/tou.py
@@ -57,7 +57,8 @@ class ToUEvent(Event):
         """
         data = super()._data_in_transforms(data)
 
-        data['event_type'] = 'tou_event'
+        if 'event_type' not in data:
+            data['event_type'] = 'tou_event'
 
         return data
 

--- a/src/eduid_userdb/tou.py
+++ b/src/eduid_userdb/tou.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 import copy
 from dataclasses import dataclass
 import datetime
-from typing import Any, ClassVar, Dict, List, Optional, Tuple, Type
+from typing import Any, Dict, List, Optional, Type
 
 from eduid_userdb.event import Event, EventList
 from eduid_userdb.exceptions import BadEvent, EduIDUserDBError, UserDBValueError
@@ -49,8 +49,6 @@ class ToUEvent(Event):
     A record of a user's acceptance of a particular version of the Terms of Use.
     """
     version: Optional[str] = None
-
-    immutable_fields: ClassVar[Tuple[str]] = ('version',)
 
     @classmethod
     def from_dict(cls: Type[ToUEvent], data: Dict[str, Any], raise_on_unknown: bool = True) -> ToUEvent:

--- a/src/eduid_userdb/tou.py
+++ b/src/eduid_userdb/tou.py
@@ -52,10 +52,10 @@ class ToUEvent(Event):
     version: Optional[str] = None
 
     @classmethod
-    def _data_in_transforms(cls: Type[ToUEvent], data: Dict[str, Any]) -> Dict[str, Any]:
+    def _from_dict_transform(cls: Type[ToUEvent], data: Dict[str, Any]) -> Dict[str, Any]:
         """
         """
-        data = super()._data_in_transforms(data)
+        data = super()._from_dict_transform(data)
 
         if 'event_type' not in data:
             data['event_type'] = 'tou_event'

--- a/src/eduid_userdb/tou.py
+++ b/src/eduid_userdb/tou.py
@@ -89,6 +89,9 @@ class ToUList(EventList):
 
     def add(self, event: ToUEvent) -> None:
         """ Add a ToUEvent to the list. """
+        if event.version is None:
+            raise ValueError('Invalid ToUEvent without version')
+
         existing = self.find(event.version)
         if existing:
             if event.created_ts >= existing.created_ts:

--- a/src/eduid_userdb/tou.py
+++ b/src/eduid_userdb/tou.py
@@ -51,10 +51,10 @@ class ToUEvent(Event):
     version: Optional[str] = None
 
     @classmethod
-    def massage_data(cls: Type[ToUEvent], data: Dict[str, Any]) -> Dict[str, Any]:
+    def data_in_transforms(cls: Type[ToUEvent], data: Dict[str, Any]) -> Dict[str, Any]:
         """
         """
-        data = super().massage_data(data)
+        data = super().data_in_transforms(data)
 
         data['event_type'] = 'tou_event'
 

--- a/src/eduid_userdb/user.py
+++ b/src/eduid_userdb/user.py
@@ -688,23 +688,19 @@ class User(object):
         return self._profiles
 
     # -----------------------------------------------------------------
-    def to_dict(self, old_userdb_format=False):
+    def to_dict(self) -> Dict[str, Any]:
         """
         Return user data serialized into a dict that can be stored in MongoDB.
 
-        :param old_userdb_format: Set to True to get the dict in the old database format.
-        :type old_userdb_format: bool
-
         :return: User as dict
-        :rtype: dict
         """
         res = copy.copy(self._data)  # avoid caller messing up our private _data
-        res['mailAliases'] = self.mail_addresses.to_list_of_dicts(old_userdb_format=old_userdb_format)
-        res['phone'] = self.phone_numbers.to_list_of_dicts(old_userdb_format=old_userdb_format)
-        res['passwords'] = self.credentials.to_list_of_dicts(old_userdb_format=old_userdb_format)
-        res['nins'] = self.nins.to_list_of_dicts(old_userdb_format=old_userdb_format)
+        res['mailAliases'] = self.mail_addresses.to_list_of_dicts()
+        res['phone'] = self.phone_numbers.to_list_of_dicts()
+        res['passwords'] = self.credentials.to_list_of_dicts()
+        res['nins'] = self.nins.to_list_of_dicts()
         res['tou'] = self.tou.to_list_of_dicts()
-        res['locked_identity'] = self.locked_identity.to_list_of_dicts(old_userdb_format=old_userdb_format)
+        res['locked_identity'] = self.locked_identity.to_list_of_dicts()
         res['orcid'] = None
         if self.orcid is not None:
             res['orcid'] = self.orcid.to_dict()
@@ -724,25 +720,6 @@ class User(object):
         ]:
             if _remove in res and not res[_remove]:
                 del res[_remove]
-        if old_userdb_format:
-            _primary = self.mail_addresses.primary
-            if _primary:
-                res['mail'] = _primary.email
-            if 'phone' in res:
-                res['mobile'] = res.pop('phone')
-            if 'surname' in res:
-                res['sn'] = res.pop('surname')
-            if 'nins' in res:
-                # Extract all verified NINs and return as a list of strings
-                _nins = res.pop('nins')
-                verified_nins = [this['number'] for this in _nins if this['verified']]
-                # don't even put 'norEduPersonNIN' in res if it is empty
-                if verified_nins:
-                    res['norEduPersonNIN'] = verified_nins
-                elif 'norEduPersonNIN' in res:
-                    del res['norEduPersonNIN']
-            if res.get('mailAliases') is list():
-                del res['mailAliases']
         return res
 
     # -----------------------------------------------------------------

--- a/src/eduid_userdb/userdb.py
+++ b/src/eduid_userdb/userdb.py
@@ -30,7 +30,8 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 import logging
-from typing import Mapping, Type
+import warnings
+from typing import Mapping, Optional, Type
 
 from bson import ObjectId
 from bson.errors import InvalidId
@@ -265,12 +266,15 @@ class UserDB(BaseDB):
             logger.error("MultipleUsersReturned, {!r} = {!r}".format(attr, value))
             raise MultipleUsersReturned(e.reason)
 
-    def save(self, user: User, check_sync: bool = True, old_format: bool = False) -> bool:
+    def save(self, user: User, check_sync: bool = True, old_format: Optional[bool] = None) -> bool:
         """
         :param user: UserClass object
         :param check_sync: Ensure the user hasn't been updated in the database since it was loaded
-        :param old_format: Save the user in legacy format in the database
+        :param old_format: Deprecated. Ignored.
         """
+        if old_format is not None:
+            warnings.warn('old_format supplied - deprecated and ignored', DeprecationWarning)
+
         if not isinstance(user, self.UserClass):
             raise EduIDUserDBError('user is not of type {}'.format(self.UserClass))
 
@@ -284,9 +288,7 @@ class UserDB(BaseDB):
         if modified is None:
             # profile has never been modified through the dashboard.
             # possibly just created in signup.
-            result = self._coll.replace_one(
-                {'_id': user.user_id}, user.to_dict(old_userdb_format=old_format), upsert=True
-            )
+            result = self._coll.replace_one({'_id': user.user_id}, user.to_dict(), upsert=True)
             logger.debug(
                 "{!s} Inserted new user {!r} into {!r} (old_format={!r}): {!r})".format(
                     self, user, self._coll_name, old_format, result
@@ -294,15 +296,13 @@ class UserDB(BaseDB):
             )
             import pprint
 
-            extra_debug = pprint.pformat(user.to_dict(old_userdb_format=old_format))
+            extra_debug = pprint.pformat(user.to_dict())
             logger.debug(f"Extra debug:\n{extra_debug}")
         else:
             test_doc = {'_id': user.user_id}
             if check_sync:
                 test_doc['modified_ts'] = modified
-            result = self._coll.replace_one(
-                test_doc, user.to_dict(old_userdb_format=old_format), upsert=(not check_sync)
-            )
+            result = self._coll.replace_one(test_doc, user.to_dict(), upsert=(not check_sync))
             if check_sync and result.modified_count == 0:
                 db_ts = None
                 db_user = self._coll.find_one({'_id': user.user_id})
@@ -314,13 +314,11 @@ class UserDB(BaseDB):
                 )
                 raise eduid_userdb.exceptions.UserOutOfSync('Stale user object can\'t be saved')
             logger.debug(
-                "{!s} Updated user {!r} (ts {!s}) in {!r} (old_format={!r}): {!r}".format(
-                    self, user, modified, self._coll_name, old_format, result
-                )
+                "{!s} Updated user {!r} (ts {!s}) in {!r}: {!r}".format(self, user, modified, self._coll_name, result)
             )
             import pprint
 
-            extra_debug = pprint.pformat(user.to_dict(old_userdb_format=old_format))
+            extra_debug = pprint.pformat(user.to_dict())
             logger.debug(f"Extra debug:\n{extra_debug}")
         return result.acknowledged
 


### PR DESCRIPTION
# Turn Element and subclasses into dataclasses.

## Dependent branches.

* These are branches for other packages fixing the effects that this PR has on them: For [eduid-common](https://github.com/SUNET/eduid-common/tree/eperez-elem-init-4), for [eduid-am](https://github.com/SUNET/eduid-am/tree/eperez-elem-init-4), and for [eduid-webapp](https://github.com/SUNET/eduid-webapp/tree/eperez-elem-init-4).

The main issues here are:

* Normalization of test data, especially regarding timestamps. They are set earlier now, and this affects the data comparisons in the tests.
* Replacement of some uses of `.from_dict(dict(` for the new constructors.
* Signature change in the constructors of some Element classes. Many constructors took a `user` param to just extract their eppn; The new constructors just take an eppn.
* Typing issues: Check that `Optional` objects are not `None`, don't reuse vars if the type changes, etc.

## Some things to take into account:

* We have removed explicit type checks, and rely now on mypy.

* We have removed the immutability at the field level. Field immutability is now not enforced, but conventional.

* With respect to timestamps, they can no longer be bools, but have a default value to utcnow (so they have a datetime value earlier than before in their lifetimes).

* Some fields are required and some have a default value, and any Element subclass can provide both. This introduces the need to add special classes just to hold the required (non default) fields, so that inheritance does not produce incorrect `__init__` methods. There is [an open issue for this in python](https://bugs.python.org/issue36077).

* I am assuming that a value of None for any field (in the python side) had in no case any special semantics other than "no value", so I am filtering those values altogether in the `to_dict` methods.

* We have removed all the `raise_on_unknown` stuff. If a dataclass receives unknown arguments it is a `TypeError` and there's no way out of it.

* We are keeping the `old_userdb_format` functionality. We might do a read out and reload all of the DB, to get rid of current "old format" fields; however, I understand we want to keep the ability to mark additional fields as "old format".

* With the Event type, we have removed the ability to have instances without `event_type` (non "mixed format") which didn't seem in use.

* There is some mismatch between the fields in OidcAuthorization (in the orcid module) and the data provided in the tests for it (test_orcid module). I have assumed the data in the tests is real data and so the OidcAuthorization class is removing data that appears in the samples but has no fields to hold them.

* Some credential objects are used in the IdP as dict keys, so I have made credentials hashable.
